### PR TITLE
squash

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -299,6 +299,8 @@
 #include "code\datums\components\armor_link.dm"
 #include "code\datums\components\bonus_damage_stack.dm"
 #include "code\datums\components\cluster_stack.dm"
+#include "code\datums\components\healing_reduction.dm"
+#include "code\datums\components\speed_modifier.dm"
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\orbiter.dm"
 #include "code\datums\components\toxin_buildup.dm"

--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -91,6 +91,7 @@
 #define REAGENT_NOT_INGESTIBLE	(1<<2) // Whether the reagent canNOT be ingested and must be delivered through injection. Used by electrogenetic property.
 #define REAGENT_CANNOT_OVERDOSE	(1<<3) // Whether the reagent canNOT trigger its overdose effects. Used by regulating property. For ordinary reagents with no overdose effect, instead keep var/overdose at 0.
 #define REAGENT_TYPE_STIMULANT  (1<<4)
+#define REAGENT_NO_GENERATION	(1<<5) // Reagent doesn't randomly generate in chemicals
 
 /*
 	properties defines
@@ -104,6 +105,7 @@
 #define PROPERTY_HEMORRAGING		"hemorrhaging"
 #define PROPERTY_CARCINOGENIC		"carcinogenic"
 #define PROPERTY_HEPATOTOXIC		"hepatotoxic"
+#define PROPERTY_INTRAVENOUS		"intravenous"
 #define PROPERTY_NEPHROTOXIC		"nephrotoxic"
 #define PROPERTY_PNEUMOTOXIC		"pneumotoxic"
 #define PROPERTY_OCULOTOXIC 		"oculotoxic"
@@ -150,6 +152,8 @@
 #define PROPERTY_BONEMENDING 		"bonemending"
 #define PROPERTY_FLUXING 			"fluxing"
 #define PROPERTY_NEUROCRYOGENIC		"neurocryogenic"
+#define PROPERTY_NEUTRALIZING		"neutralizing"
+#define PROPERTY_DISRUPTING			"disrupting"
 #define PROPERTY_ANTIPARASITIC		"anti-parasitic"
 #define PROPERTY_ELECTROGENETIC		"electrogenetic"
 #define PROPERTY_ORGANSTABILIZE		"organ-stabilizing"
@@ -227,3 +231,34 @@
 // Injectors
 #define INJECTOR_USES 3
 #define INJECTOR_PERCENTAGE_OF_OD 0.5
+
+//defines for research level multipliers
+#define RESEARCH_LEVEL_INCREASE_MULTIPLIER	3 //Scales cost of increasing clearance using credits
+#define TECHTREE_LEVEL_MULTIPLIER			2 //Scales tech level to max amplification level
+
+//Property cost multipliers for the chemical simulator
+#define PROPERTY_COST_MAX					8
+#define PROPERTY_MULTIPLIER_RARE			2
+#define PROPERTY_MULTIPLIER_ANOMALOUS		5
+
+/*
+	For minimum potencies for properties
+	Create maxes are what can be reached in create mode at a given tech level
+	Potency maxes are what can be reached in amplify mode (with unlimited levels at T3)
+*/
+#define CREATE_MAX_TIER_1					2
+#define CREATE_MAX_TIER_2					4
+#define CREATE_MAX_TIER_3					5
+#define POTENCY_MAX_TIER_1					3
+#define POTENCY_MAX_TIER_2					5
+
+//for scaling chem effects based on potency
+#define POTENCY_MULTIPLIER_VLOW				0.25
+#define POTENCY_MULTIPLIER_LOW				0.5
+#define POTENCY_MULTIPLIER_MEDIUM			2
+#define POTENCY_MULTIPLIER_HIGH				3
+#define POTENCY_MULTIPLIER_VHIGH			5
+#define POTENCY_MULTIPLIER_EXTREME			10
+
+//used in speed_modifier component
+#define HUMAN_STAMINA_MULTIPLIER 			5

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -231,6 +231,11 @@
 
 /// from /mob/living/carbon/Xenomorph/bullet_act(): (list/damagedata)
 #define COMSIG_XENO_PRE_CALCULATE_ARMOURED_DAMAGE_PROJECTILE "xeno_pre_calculate_armoured_damage_projectile"
+
+// from /mob/living/carbon/Xenomorph/proc/gain_health()
+#define COMSIG_XENO_ON_HEAL "xeno_on_heal"
+#define COMSIG_XENO_ON_HEAL_WOUNDS "xeno_on_heal_wounds"
+
 /// from /mob/living/carbon/Xenomorph/apply_armoured_damage(): (list/damagedata)
 #define COMSIG_XENO_PRE_APPLY_ARMOURED_DAMAGE "xeno_pre_apply_armoured_damage"
 

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -76,6 +76,8 @@ var/global/list/chemical_objective_list	 = list()	//List of all objective reagen
 var/global/list/chemical_identified_list = list()	//List of all identified objective reagents indexed by ID associated with the objective value
 //List of all id's from classed /datum/reagent datums indexed by class or tier. Used by chemistry generator and chem spawners.
 var/global/list/list/chemical_gen_classes_list = list("C" = list(),"C1" = list(),"C2" = list(),"C3" = list(),"C4" = list(),"C5" = list(),"C6" = list(),"T1" = list(),"T2" = list(),"T3" = list(),"T4" = list(),"tau" = list())
+//properties generated in chemicals, helps to make sure the same property doesn't show up 10 times
+GLOBAL_LIST_INIT_TYPED(generated_properties, /list, list("positive" = list(), "negative" = list(), "neutral" = list()))
 
 GLOBAL_LIST_INIT_TYPED(ammo_list, /datum/ammo, setup_ammo())					//List of all ammo types. Used by guns to tell the projectile how to act.
 GLOBAL_REFERENCE_LIST_INDEXED(joblist, /datum/job, title)					//List of all jobstypes, minus borg and AI

--- a/code/datums/components/healing_reduction.dm
+++ b/code/datums/components/healing_reduction.dm
@@ -1,0 +1,79 @@
+#define MAX_ALPHA 				35
+#define GLOW_COLOR 				"#7a0000"
+/*
+This component prevents healing under a certain strength for xenos while active.
+Healing above this strength will be reduced by the strength of the buildup.
+
+Humans will take continuous damage instead.
+*/
+
+/datum/component/healing_reduction
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	var/healing_reduction = 0
+	var/healing_reduction_dissipation = AMOUNT_PER_TIME(1, 5 SECONDS)
+	var/max_buildup = 50 //up to 50 damage off of healing max by default
+
+/datum/component/healing_reduction/Initialize(var/healing_reduction, var/healing_reduction_dissipation = AMOUNT_PER_TIME(1, 2.5 SECONDS), var/max_buildup = 50)
+	if(!isXenoOrHuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	. = ..()
+	src.healing_reduction = healing_reduction
+	src.healing_reduction_dissipation = healing_reduction_dissipation
+	src.max_buildup = max_buildup
+
+/datum/component/healing_reduction/InheritComponent(datum/component/healing_reduction/C, i_am_original, var/healing_reduction)
+	. = ..()
+	if(!C)
+		src.healing_reduction += healing_reduction
+	else
+		src.healing_reduction += C.healing_reduction
+
+	src.healing_reduction = min(src.healing_reduction, max_buildup)
+
+/datum/component/healing_reduction/process(delta_time)
+	if(!parent)
+		qdel(src)
+	healing_reduction = max(healing_reduction - healing_reduction_dissipation * delta_time, 0)
+
+	if(ishuman(parent)) //deals brute to humans
+		var/mob/living/carbon/human/H = parent
+		H.apply_damage(healing_reduction_dissipation * delta_time, BRUTE)
+
+	if(healing_reduction <= 0)
+		qdel(src)
+
+	var/color = GLOW_COLOR
+	var/intensity = healing_reduction/max_buildup
+	color += num2text(MAX_ALPHA*intensity, 2, 16)
+
+	var/atom/A = parent
+	A.add_filter("healing_reduction", 2, list("type" = "outline", "color" = color, "size" = 1))
+
+/datum/component/healing_reduction/RegisterWithParent()
+	START_PROCESSING(SSdcs, src)
+	RegisterSignal(parent, list(
+		COMSIG_XENO_ON_HEAL,
+		COMSIG_XENO_ON_HEAL_WOUNDS
+		), .proc/apply_healing_reduction)
+	RegisterSignal(parent, COMSIG_XENO_APPEND_TO_STAT, .proc/stat_append)
+
+/datum/component/healing_reduction/UnregisterFromParent()
+	STOP_PROCESSING(SSdcs, src)
+	UnregisterSignal(parent, list(
+		COMSIG_XENO_ON_HEAL,
+		COMSIG_XENO_ON_HEAL_WOUNDS,
+		COMSIG_XENO_APPEND_TO_STAT
+	))
+	var/atom/A = parent
+	A.remove_filter("healing_reduction")
+
+/datum/component/healing_reduction/proc/stat_append(var/mob/M, var/list/L)
+	SIGNAL_HANDLER
+	L += "Healing Reduction: [healing_reduction]/[max_buildup]"
+
+/datum/component/healing_reduction/proc/apply_healing_reduction(var/mob/living/carbon/Xenomorph/X, var/list/healing)
+	SIGNAL_HANDLER
+	healing["healing"] -= healing_reduction
+
+#undef MAX_ALPHA
+#undef GLOW_COLOR

--- a/code/datums/components/speed_modifier.dm
+++ b/code/datums/components/speed_modifier.dm
@@ -1,0 +1,82 @@
+#define MAX_ALPHA 					35
+#define GLOW_COLOR 					"#7a0000"
+
+//Adjusts the speed of a xenomorph the component is on. Humans will take or heal stamina damage.
+
+/datum/component/speed_modifier
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	var/speed_modifier = 0
+	var/speed_modifier_dissipation = AMOUNT_PER_TIME(1, 2.5 SECONDS)
+	var/max_buildup = 10
+	var/increase_speed = FALSE
+
+/datum/component/speed_modifier/Initialize(var/speed_modifier, var/increase_speed = FALSE, var/speed_modifier_dissipation = AMOUNT_PER_TIME(1, 2.5 SECONDS), var/max_buildup = 10)
+	if(!isXenoOrHuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	. = ..()
+	src.speed_modifier = speed_modifier
+	src.speed_modifier_dissipation = speed_modifier_dissipation
+	src.max_buildup = max_buildup
+	src.increase_speed = increase_speed
+
+/datum/component/speed_modifier/InheritComponent(datum/component/speed_modifier/C, i_am_original, var/speed_modifier)
+	. = ..()
+	if(!C)
+		src.speed_modifier += speed_modifier
+	else
+		src.speed_modifier += C.speed_modifier
+
+	src.speed_modifier = min(src.speed_modifier, max_buildup)
+
+/datum/component/speed_modifier/process(delta_time)
+	if(!parent)
+		qdel(src)
+	speed_modifier = max(speed_modifier - speed_modifier_dissipation * delta_time, 0)
+
+	if(ishuman(parent)) //Damages/heals stamina for humans
+		var/mob/living/carbon/human/H = parent
+		if(!increase_speed)
+			H.apply_stamina_damage(HUMAN_STAMINA_MULTIPLIER * speed_modifier_dissipation * delta_time)
+		else
+			H.apply_stamina_damage(-HUMAN_STAMINA_MULTIPLIER * speed_modifier_dissipation * delta_time)
+
+	if(speed_modifier <= 0)
+		qdel(src)
+
+	var/color = GLOW_COLOR
+	var/intensity = speed_modifier/max_buildup
+	color += num2text(MAX_ALPHA*intensity, 2, 16)
+
+	var/atom/A = parent
+	A.add_filter("speed_modifier", 2, list("type" = "outline", "color" = color, "size" = 1))
+
+/datum/component/speed_modifier/RegisterWithParent()
+	START_PROCESSING(SSdcs, src)
+	RegisterSignal(parent, COMSIG_XENO_MOVEMENT_DELAY, .proc/apply_speed_modifier)
+	RegisterSignal(parent, COMSIG_XENO_APPEND_TO_STAT, .proc/stat_append)
+
+/datum/component/speed_modifier/UnregisterFromParent()
+	STOP_PROCESSING(SSdcs, src)
+	UnregisterSignal(parent, list(
+		COMSIG_XENO_MOVEMENT_DELAY,
+		COMSIG_XENO_APPEND_TO_STAT
+	))
+	var/atom/A = parent
+	A.remove_filter("speed_modifier")
+
+/datum/component/speed_modifier/proc/stat_append(var/mob/M, var/list/L)
+	SIGNAL_HANDLER
+	if(!increase_speed)
+		L += "Slow: [speed_modifier]/[max_buildup]"
+	else
+		L += "Speed Boost: [speed_modifier]/[max_buildup]"
+
+/datum/component/speed_modifier/proc/apply_speed_modifier(var/mob/living/carbon/Xenomorph/X, var/list/speeds)
+	SIGNAL_HANDLER
+	if(!increase_speed)
+		speeds["speed"] += speed_modifier * 0.075
+	else //increasing speed is more effective than decreasing speed
+		speeds["speed"] -= speed_modifier * 0.1
+
+#undef MAX_ALPHA
+#undef GLOW_COLOR

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -10,7 +10,6 @@
 
 	var/research_allocation_interval = 10 MINUTES
 	var/next_research_allocation = 0
-	var/research_allocation_amount = 5
 
 	var/budget_increase_delay = 30 MINUTES
 	var/next_budget_increase = 30 MINUTES
@@ -163,7 +162,7 @@
 		return FALSE //Initial countdown, just to be safe, so that everyone has a chance to spawn before we check anything.
 
 	if(next_research_allocation < world.time)
-		chemical_data.update_credits(research_allocation_amount)
+		chemical_data.update_credits(chemical_data.research_allocation_amount)
 		next_research_allocation = world.time + research_allocation_interval
 
 	if(!round_finished)

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,6 +4,8 @@
 	required_players = 0
 	latejoin_larva_drop = 0
 	votable = FALSE
+	var/research_allocation_interval = 10 MINUTES
+	var/next_research_allocation = 0
 	taskbar_icon = 'icons/taskbar/gml_colonyrp.png'
 
 /datum/game_mode/announce()
@@ -20,6 +22,12 @@
 		np.new_player_panel_proc()
 	round_time_lobby = world.time
 	return ..()
+
+/datum/game_mode/extended/process()
+	. = ..()
+	if(next_research_allocation < world.time)
+		chemical_data.update_credits(chemical_data.research_allocation_amount)
+		next_research_allocation = world.time + research_allocation_interval
 
 /datum/game_mode/extended/check_finished()
 	if(round_finished)

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -89,7 +89,7 @@
 	var/list/data = list(
 		"rsc_credits" = chemical_data.rsc_credits,
 		"clearance_level" = chemical_data.clearance_level,
-		"broker_cost" = max(3*(chemical_data.clearance_level + 1), 1),
+		"broker_cost" = max(RESEARCH_LEVEL_INCREASE_MULTIPLIER*(chemical_data.clearance_level + 1), 1),
 		"base_purchase_cost" = base_purchase_cost,
 		"research_documents" = chemical_data.research_documents,
 		"published_documents" = chemical_data.research_publications,
@@ -139,14 +139,15 @@
 		if(alert(usr,"The CL can swipe their ID card on the console to increase clearance for free, given enough DEFCON. Are you sure you want to spend research credits to increase the clearance immediately?","Warning","Yes","No") != "Yes")
 			return
 		if(chemical_data.clearance_level < 5)
-			var/cost = max(3*(chemical_data.clearance_level + 1), 1)
+			var/cost = max(RESEARCH_LEVEL_INCREASE_MULTIPLIER*(chemical_data.clearance_level + 1), 1)
 			if(cost <= chemical_data.rsc_credits)
 				chemical_data.update_credits(cost * -1)
 				chemical_data.clearance_level++
 				visible_message(SPAN_NOTICE("Clearance access increased to level [chemical_data.clearance_level] for [cost] credits."))
 				msg_admin_niche("[key_name(user)] traded research credits to upgrade the clearance to level [chemical_data.clearance_level].")
 				if(max_clearance < chemical_data.clearance_level)
-					switch(chemical_data.clearance_level) //Gives a free research synthesis if clearance is bought, but only the first time
+					chemical_data.update_income(1) //Bonus income and a paper for buying clearance instead of swiping it up
+					switch(chemical_data.clearance_level)
 						if(2)
 							new /obj/item/paper/research_notes/unique/tier_two/(photocopier.loc)
 							max_clearance = 2

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -125,6 +125,8 @@
 				proba = 75
 			else if(R.id in list("blood", "radium", "uranium"))
 				proba = 25
+			else if(istype(R, /datum/reagent/generated)) //ensures custom chemicals will apply turf effects
+				proba = 100
 
 			spawn(0)
 				for(var/i = 0, i < runs, i++)

--- a/code/game/objects/items/reagent_containers/spray.dm
+++ b/code/game/objects/items/reagent_containers/spray.dm
@@ -19,6 +19,8 @@
 	var/list/spray_sizes = list(1,3)
 	var/safety = FALSE
 	volume = 250
+	var/last_use = 1
+	var/use_delay = 0.5 SECONDS
 
 
 /obj/item/reagent_container/spray/Initialize()
@@ -49,6 +51,9 @@
 		to_chat(user, SPAN_NOTICE("You fill \the [src] with [trans] units of the contents of \the [A]."))
 		return
 
+	if(world.time < last_use + use_delay)
+		return
+
 	if(reagents.total_volume < amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("\The [src] is empty!"))
 		return
@@ -57,6 +62,7 @@
 		to_chat(user, SPAN_WARNING("The safety is on!"))
 		return
 
+	last_use = world.time
 	Spray_at(A, user)
 
 	playsound(src.loc, 'sound/effects/spray2.ogg', 25, 1, 3)
@@ -119,6 +125,7 @@
 	possible_transfer_amounts = null
 	volume = 40
 	safety = TRUE
+	use_delay = 0.25 SECONDS
 
 
 /obj/item/reagent_container/spray/pepper/Initialize()
@@ -145,6 +152,7 @@
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = null
 	volume = 10
+	use_delay = 0.25 SECONDS
 
 /obj/item/reagent_container/spray/waterflower/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -174,6 +174,12 @@
 	if(bruteloss == 0 && fireloss == 0)
 		return
 
+	var/list/L = list("healing" = value)
+	SEND_SIGNAL(src, COMSIG_XENO_ON_HEAL, L)
+	value = L["healing"]
+	if(value < 0)
+		value = 0
+
 	if(bruteloss < value)
 		value -= bruteloss
 		bruteloss = 0

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -280,12 +280,16 @@ Xenos don't actually take oxyloss, oh well
 hmmmm, this is probably unnecessary
 Make sure their actual health updates immediately.*/
 
-#define XENO_HEAL_WOUNDS(m, recov) \
-apply_damage(-((maxHealth / 70) + 0.5 + (maxHealth / 70) * recov/2)*(m), BRUTE); \
-apply_damage(-(maxHealth / 60 + 0.5 + (maxHealth / 60) * recov/2)*(m), BURN); \
-apply_damage(-(maxHealth * 0.1 + 0.5 + (maxHealth * 0.1) * recov/2)*(m), OXY); \
-apply_damage(-(maxHealth / 5 + 0.5 + (maxHealth / 5) * recov/2)*(m), TOX); \
-updatehealth()
+/mob/living/carbon/Xenomorph/proc/heal_wounds(m, recov)
+	var/heal_penalty = 0
+	var/list/L = list("healing" = heal_penalty)
+	SEND_SIGNAL(src, COMSIG_XENO_ON_HEAL_WOUNDS, L)
+	heal_penalty = - L["healing"]
+	apply_damage(min(-((maxHealth / 70) + 0.5 + (maxHealth / 70) * recov/2)*(m) + heal_penalty, 0), BRUTE)
+	apply_damage(min(-(maxHealth / 60 + 0.5 + (maxHealth / 60) * recov/2)*(m) + heal_penalty, 0), BURN)
+	apply_damage(min(-(maxHealth * 0.1 + 0.5 + (maxHealth * 0.1) * recov/2)*(m) + heal_penalty, 0), OXY)
+	apply_damage(min(-(maxHealth / 5 + 0.5 + (maxHealth / 5) * recov/2)*(m) + heal_penalty, 0), TOX)
+	updatehealth()
 
 
 /mob/living/carbon/Xenomorph/proc/handle_environment()
@@ -316,11 +320,11 @@ updatehealth()
 			if(health < maxHealth && !hardcore && is_hive_living(hive) && last_hit_time + caste.heal_delay_time <= world.time)
 				if(lying || resting)
 					if(health < 0) //Unconscious
-						XENO_HEAL_WOUNDS(caste.heal_knocked_out * regeneration_multiplier, recoveryActual) //Healing is much slower. Warding pheromones make up for the rest if you're curious
+						heal_wounds(caste.heal_knocked_out * regeneration_multiplier, recoveryActual) //Healing is much slower. Warding pheromones make up for the rest if you're curious
 					else
-						XENO_HEAL_WOUNDS(caste.heal_resting * regeneration_multiplier, recoveryActual)
+						heal_wounds(caste.heal_resting * regeneration_multiplier, recoveryActual)
 				else
-					XENO_HEAL_WOUNDS(caste.heal_standing * regeneration_multiplier, recoveryActual)
+					heal_wounds(caste.heal_standing * regeneration_multiplier, recoveryActual)
 				updatehealth()
 
 			if(armor_integrity < armor_integrity_max && armor_deflection > 0 && world.time > armor_integrity_last_damage_time + XENO_ARMOR_REGEN_DELAY)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -570,9 +570,8 @@ This function completely restores a damaged organ to perfect condition.
 	if(brute_dam || burn_dam)
 		return TRUE
 	if(knitting_time > 0)
-		return TRUE
-	update_wounds()
-	return FALSE
+		return 1
+	return 0
 
 /obj/limb/process()
 

--- a/code/modules/reagents/Chemistry-Generator.dm
+++ b/code/modules/reagents/Chemistry-Generator.dm
@@ -176,14 +176,15 @@
 		var/gen_value
 		for(var/i=0;i<gen_tier+1;i++)
 			if(i == 0) //The first property is random to offset the value balance
-				if(gen_tier > 3 || (gen_tier == 3 && prob(50)))
+				if(gen_tier > 2)
 					gen_value = add_property(null,null,0,TRUE) //Give rare property
 				else
-					gen_value = add_property()
+					gen_value = add_property(null,null,0,FALSE,TRUE)
 			else if(gen_value == gen_tier * 2 - 1) //If we are balanced, don't add any more
 				break
-			else
-				gen_value += add_property(0,0, gen_tier - gen_value - 1) //add property based on our offset from the prefered balance
+			else if(gen_tier < 3)
+				gen_value += add_property(0,0, gen_tier - gen_value - 1,FALSE,TRUE) //add property based on our offset from the prefered balance
+			else gen_value += add_property(0,0, gen_tier - gen_value - 1)
 		while(LAZYLEN(properties) < gen_tier + 1) //We lost properties somewhere to conflicts, so add a random one until we're full
 			add_property()
 
@@ -205,7 +206,7 @@
 	generate_description()
 	return TRUE
 
-/datum/reagent/proc/add_property(var/my_property, var/my_level, var/value_offset = 0, var/make_rare = FALSE)
+/datum/reagent/proc/add_property(var/my_property, var/my_level, var/value_offset = 0, var/make_rare = FALSE, var/track_added_properties = FALSE)
 	//Determine level modifier
 	var/level
 	if(my_level)
@@ -250,9 +251,9 @@
 	else
 		switch(gen_tier)
 			if(1)
-				if(roll<=30)
+				if(roll<=20)
 					property = pick(chemical_properties_list["negative"])
-				else if (roll<=60)
+				else if (roll<=50)
 					property = pick(chemical_properties_list["neutral"])
 				else
 					property = pick(chemical_properties_list["positive"])
@@ -278,7 +279,18 @@
 				else
 					property = pick(chemical_properties_list["positive"])
 
+	if(track_added_properties) //Generated effects are more unique for lower-tier chemicals, but not higher-tier ones
+		var/property_checks = 0
+		while(!check_generated_properties(property) && property_checks < 4)
+			property_checks++
+			if(LAZYISIN(chemical_properties_list["negative"], property))
+				property = pick(chemical_properties_list["negative"])
+			else if(LAZYISIN(chemical_properties_list["neutral"], property))
+				property = pick(chemical_properties_list["neutral"])
+			else
+				property = pick(chemical_properties_list["positive"])
 	var/datum/chem_property/P = chemical_properties_list[property]
+
 	//Calculate what our chemical value is with our level
 	var/new_value
 	if(isNegativeProperty(P))
@@ -403,3 +415,19 @@
 	chemical_reactions_list[C.id] = C
 	C.add_to_filtered_list()
 	return C
+
+//Returns false if a property has been generated in a previous reagent and all properties of that category haven't been generated yet.
+/datum/reagent/proc/check_generated_properties(var/datum/chem_property/P)
+	if(LAZYISIN(chemical_properties_list["positive"], P))
+		if(LAZYISIN(GLOB.generated_properties["positive"], P) && LAZYLEN(GLOB.generated_properties["positive"]) < LAZYLEN(chemical_properties_list["positive"]))
+			return FALSE
+		GLOB.generated_properties["positive"] += P
+	else if(LAZYISIN(chemical_properties_list["negative"], P))
+		if(LAZYISIN(GLOB.generated_properties["negative"], P) && LAZYLEN(GLOB.generated_properties["negative"]) < LAZYLEN(chemical_properties_list["negative"]))
+			return FALSE
+		GLOB.generated_properties["negative"] += P
+	else if(LAZYISIN(chemical_properties_list["neutral"], P))
+		if(LAZYISIN(GLOB.generated_properties["neutral"], P) && LAZYLEN(GLOB.generated_properties["neutral"]) < LAZYLEN(chemical_properties_list["neutral"]))
+			return FALSE
+		GLOB.generated_properties["neutral"] += P
+	return TRUE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -105,16 +105,27 @@
 				if(prob(chance) && !block)
 					if(M.reagents)
 						M.reagents.add_reagent(self.id,self.volume/2)
+		for(var/datum/chem_property/P in self.properties)
+			var/potency = P.level * 0.5
+			P.reaction_mob(M, method, volume, potency)
+
+
 	return 1
 
-/datum/reagent/proc/reaction_obj(var/obj/O, var/volume) //By default we transfer a small part of the reagent to the object
-	src = null						//if it can hold reagents. nope!
+/datum/reagent/proc/reaction_obj(var/obj/O, var/volume)
+	for(var/datum/chem_property/P in properties)
+		var/potency = P.level * 0.5
+		P.reaction_obj(O, volume, potency)
+	//By default we transfer a small part of the reagent to the object
+	//if it can hold reagents. nope!
 	//if(O.reagents)
 	//	O.reagents.add_reagent(id,volume/3)
 	return
 
 /datum/reagent/proc/reaction_turf(var/turf/T, var/volume)
-	src = null
+	for(var/datum/chem_property/P in properties)
+		var/potency = P.level * 0.5
+		P.reaction_turf(T, volume, potency)
 	return
 
 /datum/reagent/proc/on_mob_life(mob/living/M, alien, var/delta_time)
@@ -243,8 +254,8 @@
 	result_amount = C.result_amount
 
 /datum/reagent/proc/save_chemclass() //Called from /datum/reagents/New()
-	//Store all classed reagents so we can easily access chem IDs based on class.
-	if(chemclass)
+	//Store all classed reagents so we can easily access chem IDs based on class. Doesn't store flagged reagents.
+	if(chemclass && !(flags && REAGENT_NO_GENERATION))
 		switch(chemclass)
 			if(CHEM_CLASS_BASIC)
 				chemical_gen_classes_list["C1"] += id

--- a/code/modules/reagents/chemical_research/Chemical-Research.dm
+++ b/code/modules/reagents/chemical_research/Chemical-Research.dm
@@ -6,6 +6,7 @@ var/global/datum/chemical_data/chemical_data = new /datum/chemical_data/
 	var/clearance_x_access = FALSE
 	var/reached_x_access = FALSE
 	var/has_new_properties = FALSE
+	var/research_allocation_amount = 5
 	var/list/research_documents = list()
 	var/list/research_publications = list()
 	var/list/research_property_data = list() //starter properties are stored here
@@ -16,6 +17,9 @@ var/global/datum/chemical_data/chemical_data = new /datum/chemical_data/
 
 /datum/chemical_data/proc/update_credits(var/change)
 	rsc_credits = max(0, rsc_credits + change)
+
+/datum/chemical_data/proc/update_income(var/change)
+	research_allocation_amount = max(0, research_allocation_amount + change)
 
 /datum/chemical_data/proc/save_document(var/obj/item/paper/research_report/R, var/document_type, var/title)
 	if(!research_documents["[document_type]"])

--- a/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
@@ -434,6 +434,9 @@
 		/obj/item/grown/nettle/death = list("pacid" = 0),
 		/obj/item/grown/nettle = list("sacid" = 0),
 
+		//Special Stuff
+		/obj/item/reagent_container/hypospray/autoinjector/yautja = list("thwei" = 30),
+
 		//Blender Stuff
 		/obj/item/reagent_container/food/snacks/grown/corn = list("cornoil" = 0)
 	)

--- a/code/modules/reagents/chemistry_properties/chem_property.dm
+++ b/code/modules/reagents/chemistry_properties/chem_property.dm
@@ -58,6 +58,15 @@
 /datum/chem_property/proc/update_reagent() //used for changing other variables in the reagent, set update to FALSE to remove the update
 	return
 
+/datum/chem_property/proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	return
+
+/datum/chem_property/proc/reaction_obj(var/obj/O, var/volume, var/potency)
+	return
+
+/datum/chem_property/proc/reaction_turf(var/turf/T, var/volume, var/potency)
+	return
+
 /datum/chem_property/proc/post_update_reagent()
 	return
 

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -15,16 +15,16 @@
 
 /datum/chem_property/negative/hypoxemic/process(mob/living/M, var/potency = 1, delta_time)
 	..()
-	M.apply_damage(potency * delta_time, OXY)
-	if(prob(5 * delta_time))
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, OXY)
+	if(prob(10))
 		M.emote("gasp")
 
-/datum/chem_property/negative/hypoxemic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0.5 * potency * delta_time, 0, potency)
-	M.apply_damage(2.5 * potency * delta_time, OXY)
+/datum/chem_property/negative/hypoxemic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damages(potency, 0, potency)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
-/datum/chem_property/negative/hypoxemic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(2.5 * potency * delta_time, 0, potency * delta_time)
+/datum/chem_property/negative/hypoxemic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_VHIGH * potency, 0, POTENCY_MULTIPLIER_MEDIUM*potency)
 
 /datum/chem_property/negative/toxic
 	name = PROPERTY_TOXIC
@@ -41,8 +41,41 @@
 /datum/chem_property/negative/toxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(potency * delta_time, TOX)
 
-/datum/chem_property/negative/toxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2 * potency * delta_time, TOX)
+/datum/chem_property/negative/toxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(potency * POTENCY_MULTIPLIER_VHIGH, TOX)
+
+/datum/chem_property/negative/toxic/reaction_obj(var/obj/O, var/volume, var/potency = 1)
+	if(istype(O,/obj/effect/alien/weeds/))
+		var/obj/effect/alien/weeds/alien_weeds = O
+		alien_weeds.take_damage(25 * potency) // Kills alien weeds on touch
+		return
+	if(istype(O,/obj/effect/glowshroom))
+		qdel(O)
+		return
+	if(istype(O,/obj/effect/plantsegment))
+		if(prob(50)) qdel(O)
+		return
+	if(istype(O,/obj/structure/machinery/portable_atmospherics/hydroponics))
+		var/obj/structure/machinery/portable_atmospherics/hydroponics/tray = O
+
+		if(!tray.seed)
+			return
+		tray.health -= rand(30,50)
+		if(tray.pestlevel > 0)
+			tray.pestlevel -= 2
+		if(tray.weedlevel > 0)
+			tray.weedlevel -= 3
+		tray.toxins += 4
+		tray.check_level_sanity()
+		tray.update_icon()
+
+/datum/chem_property/negative/toxic/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume, var/potency = 1)
+	if(!iscarbon(M))
+		return
+	var/mob/living/carbon/C = M
+	if(!C.wear_mask) // If not wearing a mask
+		return
+	C.apply_damage(potency, TOX) // applies potency toxin damage
 
 /datum/chem_property/negative/corrosive
 	name = PROPERTY_CORROSIVE
@@ -50,17 +83,85 @@
 	description = "Damages or destroys other substances on contact through a chemical reaction. Causes chemical burns on contact with living tissue."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
-	value = -1
+	value = 1 //has a combat use
 
 /datum/chem_property/negative/corrosive/process(mob/living/M, var/potency = 1, delta_time)
 	..()
 	M.take_limb_damage(0, 0.5 * potency * delta_time)
 
-/datum/chem_property/negative/corrosive/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(0, potency * delta_time)
+/datum/chem_property/negative/corrosive/process_overdose(mob/living/M, var/potency = 1)
+	M.take_limb_damage(0,POTENCY_MULTIPLIER_MEDIUM*potency)
 
-/datum/chem_property/negative/corrosive/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(0, 2 * potency * delta_time)
+/datum/chem_property/negative/corrosive/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(0,POTENCY_MULTIPLIER_VHIGH*potency)
+
+/datum/chem_property/negative/corrosive/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume, var/potency) //from sacid
+	var/meltprob = potency * POTENCY_MULTIPLIER_HIGH
+	if(!istype(M, /mob/living))
+		return
+	if(method == TOUCH)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.head)
+				if(prob(meltprob) && !H.head.unacidable)
+					to_chat(H, SPAN_DANGER("Your headgear melts away but protects you from the acid!"))
+					qdel(H.head)
+					H.update_inv_head(0)
+					H.update_hair(0)
+				else
+					to_chat(H, SPAN_WARNING("Your headgear protects you from the acid."))
+				return
+
+			if(H.wear_mask)
+				if(prob(meltprob) && !H.wear_mask.unacidable)
+					to_chat(H, SPAN_DANGER("Your mask melts away but protects you from the acid!"))
+					qdel(H.wear_mask)
+					H.update_inv_wear_mask(0)
+					H.update_hair(0)
+				else
+					to_chat(H, SPAN_WARNING("Your mask protects you from the acid."))
+				return
+
+			if(H.glasses)
+				if(prob(meltprob) && !H.glasses.unacidable)
+					to_chat(H, SPAN_DANGER("Your glasses melts away!"))
+					qdel(H.glasses)
+					H.update_inv_glasses(0)
+				return
+
+		if(!M.unacidable) //nothing left to melt, apply acid effects
+			if(istype(M, /mob/living/carbon/human) && volume >= 10)
+				var/mob/living/carbon/human/H = M
+				var/obj/limb/affecting = H.get_limb("head")
+				if(affecting)
+					if(affecting.take_damage(4, 2))
+						H.UpdateDamageIcon()
+					if(prob(meltprob)) //Applies disfigurement
+						if(H.pain.feels_pain)
+							H.emote("scream")
+						H.status_flags |= DISFIGURED
+						H.name = H.get_visible_name()
+			else
+				M.take_limb_damage(min(6, volume))
+			return
+	else
+		if(!M.unacidable)
+			M.take_limb_damage(min(6, volume))
+	if(isXeno(M))
+		var/mob/living/carbon/Xenomorph/X = M
+		if(potency > POTENCY_MAX_TIER_1) //Needs level 7+ to have any effect
+			X.AddComponent(/datum/component/toxic_buildup, potency * volume * 0.25)
+			to_chat(X, SPAN_XENODANGER("The corrosive substance damages your carapace!"))
+
+/datum/chem_property/negative/corrosive/reaction_obj(var/obj/O, var/volume, var/potency)
+	if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(potency * 10))
+		if(O.unacidable)
+			return
+		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
+		I.desc = "Looks like this was \an [O] some time ago."
+		for(var/mob/M in viewers(5, O))
+			to_chat(M, SPAN_WARNING("\the [O] melts."))
+		qdel(O)
 
 /datum/chem_property/negative/biocidic
 	name = PROPERTY_BIOCIDIC
@@ -74,11 +175,11 @@
 	..()
 	M.take_limb_damage(0.5 * potency * delta_time)
 
-/datum/chem_property/negative/biocidic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(potency * delta_time)
+/datum/chem_property/negative/biocidic/process_overdose(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_MEDIUM * potency)
 
-/datum/chem_property/negative/biocidic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(2 * potency * delta_time)
+/datum/chem_property/negative/biocidic/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_VHIGH * potency)
 
 /datum/chem_property/negative/paining
 	name = PROPERTY_PAINING
@@ -106,8 +207,8 @@
 	M.pain.apply_pain(PROPERTY_PAINING_PAIN_OD * potency)
 	M.take_limb_damage(0.5 * potency * delta_time)
 
-/datum/chem_property/negative/paining/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(potency * delta_time)
+/datum/chem_property/negative/paining/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_MEDIUM * potency)
 
 /datum/chem_property/negative/hemolytic
 	name = PROPERTY_HEMOLYTIC
@@ -120,7 +221,7 @@
 		return
 	var/mob/living/carbon/C = M
 	..()
-	C.blood_volume = max(C.blood_volume - 2 * potency * delta_time, 0)
+	C.blood_volume = max(C.blood_volume - POTENCY_MULTIPLIER_VHIGH * potency,0)
 
 /datum/chem_property/negative/hemolytic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!iscarbon(M))
@@ -133,14 +234,15 @@
 	if(prob(5 * delta_time))
 		M.emote(pick("yawn","gasp"))
 
-/datum/chem_property/negative/hemolytic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2 * potency * delta_time, OXY)
+/datum/chem_property/negative/hemolytic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
 /datum/chem_property/negative/hemorrhaging
 	name = PROPERTY_HEMORRAGING
 	code = "HMR"
 	description = "Ruptures endothelial cells making up bloodvessels, causing blood to escape from the circulatory system."
 	rarity = PROPERTY_UNCOMMON
+	value = 2
 
 /datum/chem_property/negative/hemorrhaging/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
@@ -150,11 +252,11 @@
 	if(!L || L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		return
 	..()
-	if(prob(2.5 * potency * delta_time))
+	if(prob(POTENCY_MULTIPLIER_VHIGH * potency))
 		var/datum/wound/internal_bleeding/I = new (0)
 		L.add_bleeding(I, TRUE)
 		L.wounds += I
-	if(prob(2.5 * potency * delta_time))
+	if(prob(POTENCY_MULTIPLIER_VHIGH * potency))
 		spawn L.owner.emote("me", 1, "coughs up blood!")
 		L.owner.drip(10)
 
@@ -165,7 +267,7 @@
 	var/obj/limb/L = pick(H.limbs)
 	if(L.internal_organs)
 		var/datum/internal_organ/O = pick(L.internal_organs)//Organs can't bleed, so we just damage them
-		O.damage += 0.25 * potency * delta_time
+		O.damage += POTENCY_MULTIPLIER_LOW * potency
 
 /datum/chem_property/negative/hemorrhaging/process_critical(mob/living/M, var/potency = 1, delta_time)
 	if(prob(10 * potency * delta_time) && ishuman(M))
@@ -175,6 +277,9 @@
 		L.add_bleeding(I, TRUE)
 		L.wounds += I
 
+/datum/chem_property/negative/hemorrhaging/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency)
+	M.AddComponent(/datum/component/healing_reduction, potency * volume * POTENCY_MULTIPLIER_VLOW) //deals brute DOT to humans, prevents healing for xenos
+
 /datum/chem_property/negative/carcinogenic
 	name = PROPERTY_CARCINOGENIC
 	code = "CRG"
@@ -183,13 +288,13 @@
 
 /datum/chem_property/negative/carcinogenic/process(mob/living/M, var/potency = 1, delta_time)
 	..()
-	M.adjustCloneLoss(0.25 * potency * delta_time)
+	M.adjustCloneLoss(POTENCY_MULTIPLIER_LOW*potency)
 
-/datum/chem_property/negative/carcinogenic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.adjustCloneLoss(potency * delta_time)
+/datum/chem_property/negative/carcinogenic/process_overdose(mob/living/M, var/potency = 1)
+	M.adjustCloneLoss(POTENCY_MULTIPLIER_MEDIUM * potency)
 
-/datum/chem_property/negative/carcinogenic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(potency * delta_time) //Hyperactive apoptosis
+/datum/chem_property/negative/carcinogenic/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_MEDIUM * potency)//Hyperactive apoptosis
 
 /datum/chem_property/negative/hepatotoxic
 	name = PROPERTY_HEPATOTOXIC
@@ -201,13 +306,29 @@
 	if(!ishuman(M))
 		return
 	..()
-	M.apply_internal_damage(0.375 * potency * delta_time, "liver")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_LOW * potency, "liver")
 
-/datum/chem_property/negative/hepatotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/negative/hepatotoxic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, TOX)
 
-/datum/chem_property/negative/hepatotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, TOX)
+/datum/chem_property/negative/hepatotoxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, TOX)
+
+/datum/chem_property/negative/intravenous
+	name = PROPERTY_INTRAVENOUS
+	code = "INV"
+	description = "Due to chemical composition, this chemical can only be administered intravenously."
+	rarity = PROPERTY_COMMON
+	category = PROPERTY_TYPE_METABOLITE
+	max_level = 1
+
+/datum/chem_property/negative/intravenous/reset_reagent()
+	holder.flags = initial(holder.flags)
+	return ..()
+
+/datum/chem_property/negative/intravenous/update_reagent()
+	holder.flags |= REAGENT_NOT_INGESTIBLE
+	return ..()
 
 /datum/chem_property/negative/nephrotoxic
 	name = PROPERTY_NEPHROTOXIC
@@ -219,13 +340,13 @@
 	if(!ishuman(M))
 		return
 	..()
-	M.apply_internal_damage(0.375 * potency * delta_time, "kidneys")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_LOW * potency, "kidneys")
 
-/datum/chem_property/negative/nephrotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/negative/nephrotoxic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, TOX)
 
-/datum/chem_property/negative/nephrotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, TOX)
+/datum/chem_property/negative/nephrotoxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, TOX)
 
 /datum/chem_property/negative/pneumotoxic
 	name = PROPERTY_PNEUMOTOXIC
@@ -237,13 +358,13 @@
 	if(!ishuman(M))
 		return
 	..()
-	M.apply_internal_damage(0.375 * potency * delta_time, "lungs")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_LOW * potency, "lungs")
 
-/datum/chem_property/negative/pneumotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, OXY)
+/datum/chem_property/negative/pneumotoxic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, OXY)
 
-/datum/chem_property/negative/pneumotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, OXY)
+/datum/chem_property/negative/pneumotoxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
 /datum/chem_property/negative/oculotoxic
 	name = PROPERTY_OCULOTOXIC
@@ -258,13 +379,13 @@
 	var/mob/living/carbon/human/H = M
 	var/datum/internal_organ/eyes/L = H.internal_organs_by_name["eyes"]
 	if(L)
-		L.damage += 0.375 * potency * delta_time
+		L.damage += POTENCY_MULTIPLIER_LOW * potency
 
 /datum/chem_property/negative/oculotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.sdisabilities |= DISABILITY_BLIND
 
-/datum/chem_property/negative/oculotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(0.25 * potency * delta_time, BRAIN)
+/datum/chem_property/negative/oculotoxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_LOW * potency, BRAIN)
 
 /datum/chem_property/negative/cardiotoxic
 	name = PROPERTY_CARDIOTOXIC
@@ -276,35 +397,42 @@
 	if(!ishuman(M))
 		return
 	..()
-	M.apply_internal_damage(0.375 * potency * delta_time, "heart")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_LOW * potency, "heart")
 
-/datum/chem_property/negative/cardiotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, OXY)
+/datum/chem_property/negative/cardiotoxic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, OXY)
 
-/datum/chem_property/negative/cardiotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, OXY)
+/datum/chem_property/negative/cardiotoxic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
 /datum/chem_property/negative/neurotoxic
 	name = PROPERTY_NEUROTOXIC
 	code = "NRT"
-	description = "Breaks down neurons causing widespread damage to the central nervous system and brain functions."
+	description = "Breaks down neurons causing widespread damage to the central nervous system and brain functions. Exposure may cause disorientation or unconsciousness to affected persons."
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_TOXICANT|PROPERTY_TYPE_STIMULANT
 
-/datum/chem_property/negative/neurotoxic/process(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, BRAIN)
+/datum/chem_property/negative/neurotoxic/process(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, BRAIN)
 
-/datum/chem_property/negative/neurotoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(1.5 * potency * delta_time, BRAIN)
-	M.jitteriness = min(M.jitteriness + 0.5 * potency * delta_time, 3 * potency)
-	if(prob(25 * delta_time))
-		M.drowsyness = min(M.drowsyness + 0.5 * potency * delta_time, 3 * potency)
-	if(prob(5 * delta_time))
+/datum/chem_property/negative/neurotoxic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_HIGH * potency, BRAIN)
+	M.jitteriness = min(M.jitteriness + potency, POTENCY_MULTIPLIER_HIGH * potency)
+	if(prob(50))
+		M.drowsyness = min(M.drowsyness + potency, POTENCY_MULTIPLIER_HIGH * potency)
+	if(prob(10))
 		M.emote("drool")
 
-/datum/chem_property/negative/neurotoxic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	if(prob(7.5 * potency * delta_time))
-		apply_neuro(M, potency * delta_time, FALSE)
+/datum/chem_property/negative/neurotoxic/process_critical(mob/living/M, var/potency = 1)
+	if(prob(15*potency))
+		apply_neuro(M, POTENCY_MULTIPLIER_MEDIUM * potency, FALSE)
+
+/datum/chem_property/negative/neurotoxic/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.apply_damage(potency, BRAIN)
+	to_chat(M, SPAN_WARNING("You start to go numb."))
+	M.Daze(potency * volume * POTENCY_MULTIPLIER_LOW)
 
 /datum/chem_property/negative/hypermetabolic
 	name = PROPERTY_HYPERMETABOLIC
@@ -318,7 +446,7 @@
 	..()
 
 /datum/chem_property/negative/hypermetabolic/update_reagent()
-	holder.custom_metabolism = holder.custom_metabolism * (1 + 0.25 * level)
+	holder.custom_metabolism = holder.custom_metabolism * (1 + POTENCY_MULTIPLIER_VLOW * level)
 	..()
 
 /datum/chem_property/negative/addictive
@@ -365,15 +493,15 @@
 		return
 	..()
 	var/mob/living/carbon/C = M
-	C.blood_volume = max(C.blood_volume - 2.5 * potency * delta_time, 0)
-	holder.volume += 0.5 * potency * delta_time
+	C.blood_volume = max(C.blood_volume - POTENCY_MULTIPLIER_VHIGH * potency, 0)
+	holder.volume++
 
 /datum/chem_property/negative/hemositic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!iscarbon(M))
 		return
 	var/mob/living/carbon/C = M
-	C.blood_volume = max(C.blood_volume - 5 * potency * delta_time, 0)
-	holder.volume += potency * delta_time
+	C.blood_volume = max(C.blood_volume-10*potency,0)
+	holder.volume += potency * POTENCY_MULTIPLIER_MEDIUM
 
 /datum/chem_property/negative/hemositic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.disabilities |= NERVOUS

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -14,7 +14,7 @@
 /datum/chem_property/neutral/cryometabolizing/pre_process(mob/living/M)
 	if(M.bodytemperature > 170)
 		return list(REAGENT_CANCEL = TRUE)
-	return list(REAGENT_BOOST = 0.5 * level)
+	return list(REAGENT_BOOST = POTENCY_MULTIPLIER_LOW * level)
 
 /datum/chem_property/neutral/thanatometabolizing
 	name = PROPERTY_THANATOMETABOL
@@ -75,12 +75,12 @@
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_METABOLITE
 
-/datum/chem_property/neutral/ketogenic/process(mob/living/M, var/potency = 1, delta_time)
-	M.nutrition = max(M.nutrition - 2.5 * potency * delta_time, 0)
+/datum/chem_property/neutral/ketogenic/process(mob/living/M, var/potency = 1)
+	M.nutrition = max(M.nutrition - POTENCY_MULTIPLIER_VHIGH * potency, 0)
 	M.overeatduration = 0
-	if(M.reagents.remove_all_type(/datum/reagent/ethanol, 0.5 * potency * delta_time, 0, 1)) //Ketosis causes rapid metabolization of alcohols
-		M.confused = min(M.confused + 0.5 * potency * delta_time, 10 * potency)
-		M.drowsyness = min(M.drowsyness + 0.5 * potency * delta_time, 15 * potency)
+	if(M.reagents.remove_all_type(/datum/reagent/ethanol, potency, 0, 1)) //Ketosis causes rapid metabolization of alcohols
+		M.confused = min(M.confused + potency,10*potency)
+		M.drowsyness = min(M.drowsyness + potency,15*potency)
 
 /datum/chem_property/neutral/ketogenic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.nutrition = max(M.nutrition - 5 * potency * delta_time, 0)
@@ -119,8 +119,8 @@
 	M.apply_damage(0.5 * potency * delta_time, BRAIN)
 	M.disabilities |= NERVOUS
 
-/datum/chem_property/neutral/neuroinhibiting/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, BRAIN)
+/datum/chem_property/neutral/neuroinhibiting/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM * potency, BRAIN)
 
 /datum/chem_property/neutral/alcoholic
 	name = PROPERTY_ALCOHOLIC
@@ -148,7 +148,7 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/internal_organ/liver/L = H.internal_organs_by_name["liver"]
 		if(L)
-			L.damage += 0.25 * potency * delta_time
+			L.damage += POTENCY_MULTIPLIER_LOW * potency
 
 /datum/chem_property/neutral/hallucinogenic
 	name = PROPERTY_HALLUCINOGENIC
@@ -160,8 +160,8 @@
 /datum/chem_property/neutral/hallucinogenic/process(mob/living/M, var/potency = 1, delta_time)
 	if(prob(5 * delta_time))
 		M.emote(pick("twitch","drool","moan","giggle"))
-	if(potency > 2)
-		M.hallucination = min(M.hallucination + 0.5 * potency * delta_time, potency * 10)
+	if(potency > CREATE_MAX_TIER_1)
+		M.hallucination = min(M.hallucination + potency, potency * 10)
 		M.make_jittery(5)
 	M.druggy = min(M.druggy + 0.5 * potency * delta_time, potency * 10)
 
@@ -190,8 +190,8 @@
 
 /datum/chem_property/neutral/relaxing/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	//heart beats slower
-	M.reagent_move_delay_modifier += 2*potency
-	if(prob(5 * delta_time))
+	M.reagent_move_delay_modifier += POTENCY_MULTIPLIER_MEDIUM * potency
+	if(prob(10))
 		to_chat(M, SPAN_WARNING("You feel incredibly weak!"))
 
 /datum/chem_property/neutral/relaxing/process_critical(mob/living/M, var/potency = 1, delta_time)
@@ -201,7 +201,7 @@
 	M.apply_damage(0.5 * potency * delta_time, OXY)
 	if(prob(2.5 * delta_time))
 		to_chat(M, SPAN_WARNING("You can hardly breathe!"))
-	M.apply_internal_damage(0.375 * potency * delta_time, "heart")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_LOW * potency, "heart")
 
 /datum/chem_property/neutral/hyperthermic
 	name = PROPERTY_HYPERTHERMIC
@@ -215,15 +215,15 @@
 	if(prob(5 * delta_time))
 		M.emote("gasp")
 		to_chat(M, SPAN_DANGER("<b>Your insides feel uncomfortably hot !</b>"))
-	M.bodytemperature = max(M.bodytemperature + potency * delta_time, 0)
-	if(potency >= 2)
-		M.make_dizzy(potency * delta_time)
-		M.apply_effect(0.5 * potency * delta_time, AGONY, 0)
+	M.bodytemperature = max(M.bodytemperature + POTENCY_MULTIPLIER_MEDIUM * potency,0)
+	if(potency >= CREATE_MAX_TIER_1)
+		M.make_dizzy(potency * POTENCY_MULTIPLIER_MEDIUM)
+		M.apply_effect(potency,AGONY,0)
 	M.recalculate_move_delay = TRUE
 
-/datum/chem_property/neutral/hyperthermic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.bodytemperature = max(M.bodytemperature + 2 * potency * delta_time, 0)
-	M.apply_effect(potency * delta_time, AGONY, 0)
+/datum/chem_property/neutral/hyperthermic/process_overdose(mob/living/M, var/potency = 1)
+	M.bodytemperature = max(M.bodytemperature + POTENCY_MULTIPLIER_VHIGH * potency,0)
+	M.apply_effect(POTENCY_MULTIPLIER_MEDIUM * potency,AGONY,0)
 
 /datum/chem_property/neutral/hyperthermic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.KnockOut(20)
@@ -238,11 +238,11 @@
 /datum/chem_property/neutral/hypothermic/process(mob/living/M, var/potency = 1, delta_time)
 	if(prob(5 * delta_time))
 		M.emote("shiver")
-	M.bodytemperature = max(M.bodytemperature - potency * delta_time, 0)
+	M.bodytemperature = max(M.bodytemperature - POTENCY_MULTIPLIER_MEDIUM * potency,0)
 	M.recalculate_move_delay = TRUE
 
-/datum/chem_property/neutral/hypothermic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.bodytemperature = max(M.bodytemperature - 2 * potency * delta_time, 0)
+/datum/chem_property/neutral/hypothermic/process_overdose(mob/living/M, var/potency = 1)
+	M.bodytemperature = max(M.bodytemperature - POTENCY_MULTIPLIER_VHIGH * potency,0)
 	M.drowsyness  = max(M.drowsyness, 30)
 
 /datum/chem_property/neutral/hypothermic/process_critical(mob/living/M, var/potency = 1, delta_time)
@@ -266,8 +266,8 @@
 			H.f_style = "Shaved"
 			H.update_hair()
 
-/datum/chem_property/neutral/balding/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.adjustCloneLoss(0.25 * potency * delta_time)
+/datum/chem_property/neutral/balding/process_overdose(mob/living/M, var/potency = 1)
+	M.adjustCloneLoss(POTENCY_MULTIPLIER_LOW * potency)
 
 /datum/chem_property/neutral/balding/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.adjustCloneLoss(0.5 * potency * delta_time)
@@ -307,8 +307,8 @@
 	category = PROPERTY_TYPE_IRRITANT
 	value = 0
 
-/datum/chem_property/neutral/allergenic/process(mob/living/M, var/potency = 1, delta_time)
-	if(prob(2.5 * potency * delta_time))
+/datum/chem_property/neutral/allergenic/process(mob/living/M, var/potency = 1)
+	if(prob(POTENCY_MULTIPLIER_VHIGH * potency))
 		M.emote(pick("sneeze","blink","cough"))
 
 /datum/chem_property/neutral/euphoric
@@ -329,15 +329,15 @@
 		return
 
 	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * potency) //Endorphins are natural painkillers
-	if(prob(2.5 * potency * delta_time))
+	if(prob(POTENCY_MULTIPLIER_VHIGH * potency))
 		M.emote(pick("laugh","giggle","chuckle","grin","smile","twitch"))
 
-/datum/chem_property/neutral/euphoric/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	if(prob(2.5 * potency * delta_time))
+/datum/chem_property/neutral/euphoric/process_overdose(mob/living/M, var/potency = 1)
+	if(prob(POTENCY_MULTIPLIER_VHIGH * potency))
 		M.emote("collapse") //ROFL
 
-/datum/chem_property/neutral/euphoric/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(1.5 * potency * delta_time, OXY)
+/datum/chem_property/neutral/euphoric/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 	to_chat(M, SPAN_WARNING("You are laughing so much you can't breathe!"))
 
 /datum/chem_property/neutral/emetic
@@ -352,11 +352,11 @@
 		var/mob/living/carbon/human/H = M
 		H.vomit() //vomit() already has a timer on in
 
-/datum/chem_property/neutral/emetic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(0.25 * potency * delta_time, TOX)
+/datum/chem_property/neutral/emetic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_LOW * potency, TOX)
 
-/datum/chem_property/neutral/emetic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(0.25 * potency * delta_time, TOX)
+/datum/chem_property/neutral/emetic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_LOW * potency, TOX)
 
 /datum/chem_property/neutral/psychostimulating
 	name = PROPERTY_PSYCHOSTIMULATING
@@ -399,7 +399,7 @@
 
 /datum/chem_property/neutral/psychostimulating/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.hallucination = min(200, M.hallucination)
-	M.apply_damage(2 * potency * delta_time, BRAIN)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, BRAIN)
 
 /datum/chem_property/neutral/antihallucinogenic
 	name = PROPERTY_ANTIHALLUCINOGENIC
@@ -409,17 +409,17 @@
 	category = PROPERTY_TYPE_STIMULANT
 	value = 1
 
-/datum/chem_property/neutral/antihallucinogenic/process(mob/living/M, var/potency = 1, delta_time)
-	M.reagents.remove_reagent("mindbreaker", 2.5 * delta_time)
-	M.reagents.remove_reagent("space_drugs", 2.5 * delta_time)
-	M.hallucination = max(0, M.hallucination - 5 * potency * delta_time)
-	M.druggy = max(0, M.druggy - 5 * potency * delta_time)
+/datum/chem_property/neutral/antihallucinogenic/process(mob/living/M, var/potency = 1)
+	M.reagents.remove_reagent("mindbreaker", 5)
+	M.reagents.remove_reagent("space_drugs", 5)
+	M.hallucination = max(0, M.hallucination - POTENCY_MULTIPLIER_EXTREME * potency)
+	M.druggy = max(0, M.druggy - POTENCY_MULTIPLIER_EXTREME * potency)
 
 /datum/chem_property/neutral/antihallucinogenic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(0.5 * potency * delta_time, TOX)
 
-/datum/chem_property/neutral/antihallucinogenic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0.5 * potency * delta_time, 0.5 * potency * delta_time, 1.5 * potency * delta_time)
+/datum/chem_property/neutral/antihallucinogenic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(potency, potency, POTENCY_MULTIPLIER_HIGH * potency)
 
 /datum/chem_property/neutral/hypometabolic
 	name = PROPERTY_HYPOMETABOLIC
@@ -446,18 +446,18 @@
 
 /datum/chem_property/neutral/sedative/process(mob/living/M, var/potency = 1, delta_time)
 	if(M.confused < 25 && M.sleeping < 20)
-		M.confused += potency * delta_time
+		M.confused += POTENCY_MULTIPLIER_MEDIUM * potency
 	if(M.confused > 25)
-		M.AdjustSleeping(potency * delta_time)
-		M.confused -= potency * delta_time //so when they wake up they aren't still confused
-	else if(prob(12.5 * delta_time))
+		M.AdjustSleeping(POTENCY_MULTIPLIER_MEDIUM * potency)
+		M.confused -= POTENCY_MULTIPLIER_MEDIUM * potency //so when they wake up they aren't still confused
+	else if(prob(25))
 		M.emote("yawn")
 
 /datum/chem_property/neutral/sedative/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.AdjustKnockedout(0.5 * potency * delta_time)
 
-/datum/chem_property/neutral/sedative/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, OXY)
+/datum/chem_property/neutral/sedative/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
 /datum/chem_property/neutral/hyperthrottling
 	name = PROPERTY_HYPERTHROTTLING
@@ -471,7 +471,7 @@
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/H = M
-	M.reagent_move_delay_modifier += 4 * potency
+	M.reagent_move_delay_modifier += POTENCY_MULTIPLIER_HIGH * potency
 	M.recalculate_move_delay = TRUE
 	M.druggy = min(M.druggy + 0.5 * potency * delta_time, 10)
 	if(H.chem_effect_flags & CHEM_EFFECT_HYPER_THROTTLE)
@@ -532,25 +532,25 @@
 	description = "Removes common alcoholic substances from the bloodstream and increases focus."
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_STIMULANT
-	value = 1
+	value = 0
 
-/datum/chem_property/neutral/focusing/process(mob/living/M, var/potency = 1, delta_time)
-	M.reagents.remove_all_type(/datum/reagent/ethanol, 0.5 * potency * delta_time, 0, 1)
-	M.stuttering = max(M.stuttering - potency * delta_time, 0)
-	M.confused = max(M.confused - potency * delta_time, 0)
-	M.eye_blurry = max(M.eye_blurry - potency * delta_time, 0)
-	M.drowsyness = max(M.drowsyness - potency * delta_time, 0)
-	M.dizziness = max(M.dizziness - potency * delta_time, 0)
-	M.jitteriness = max(M.jitteriness - potency * delta_time, 0)
-	if(potency >= 3)
+/datum/chem_property/neutral/focusing/process(mob/living/M, var/potency = 1)
+	M.reagents.remove_all_type(/datum/reagent/ethanol, potency, 0, 1)
+	M.stuttering = max(M.stuttering - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	M.confused = max(M.confused - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	M.eye_blurry = max(M.eye_blurry - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	M.drowsyness = max(M.drowsyness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	M.dizziness = max(M.dizziness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	M.jitteriness = max(M.jitteriness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+	if(potency >= POTENCY_MAX_TIER_1)
 		M.eye_blind = 0
 		M.silent = 0
 
-/datum/chem_property/neutral/focusing/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(0.5 * delta_time, TOX)
+/datum/chem_property/neutral/focusing/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/neutral/focusing/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2 * delta_time, TOX)
+/datum/chem_property/neutral/focusing/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(potency * POTENCY_MULTIPLIER_HIGH, TOX)
 
 /datum/chem_property/neutral/transformative
 	name = PROPERTY_TRANSFORMATIVE
@@ -570,8 +570,8 @@
 		M.apply_damage(-true_heal, BURN)
 		M.apply_damage(true_heal * 0.1, TOX)
 
-/datum/chem_property/neutral/transformative/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(heal_amount * (potency * 0.5) * delta_time, TOX)
+/datum/chem_property/neutral/transformative/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(heal_amount * (potency * POTENCY_MULTIPLIER_LOW), TOX)
 
 /datum/chem_property/neutral/transformative/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(heal_amount * potency * delta_time, TOX)
@@ -586,5 +586,5 @@
 /datum/chem_property/neutral/unknown/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(0.5 * potency * delta_time, BRUTE)
 
-/datum/chem_property/neutral/unknown/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(1.5 * potency * delta_time, 1.5 * potency * delta_time, 1.5 * potency * delta_time)
+/datum/chem_property/neutral/unknown/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_HIGH * potency, POTENCY_MULTIPLIER_HIGH * potency, POTENCY_MULTIPLIER_HIGH * potency)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -11,9 +11,9 @@
 	starter = TRUE
 	value = 1
 
-/datum/chem_property/positive/antitoxic/process(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(-(0.5 * potency * delta_time), TOX)
-	M.reagents.remove_all_type(/datum/reagent/toxin, 0.5 * REM * delta_time, 0, 1)
+/datum/chem_property/positive/antitoxic/process(mob/living/M, var/potency = 1)
+	M.apply_damage(-(potency * POTENCY_MULTIPLIER_MEDIUM), TOX)
+	M.reagents.remove_all_type(/datum/reagent/toxin, REM, 0, 1)
 
 /datum/chem_property/positive/antitoxic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_internal_damage(0.5 * potency * delta_time, "eyes")
@@ -29,14 +29,16 @@
 	starter = TRUE
 	value = 1
 
-/datum/chem_property/positive/anticorrosive/process(mob/living/M, var/potency = 1, delta_time)
-	M.heal_limb_damage(0, 0.5 * potency * delta_time)
+/datum/chem_property/positive/anticorrosive/process(mob/living/M, var/potency = 1)
+	M.heal_limb_damage(0, potency)
+	if(potency > CREATE_MAX_TIER_1)
+		M.heal_limb_damage(0, potency * POTENCY_MULTIPLIER_LOW)
 
 /datum/chem_property/positive/anticorrosive/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damages(0.5 * potency * delta_time, 0, 0.5 * potency * delta_time) //Mixed brute/tox damage
 
-/datum/chem_property/positive/anticorrosive/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(2 * potency * delta_time, 0, 2 * potency * delta_time) //Massive brute/tox damage
+/datum/chem_property/positive/anticorrosive/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_VHIGH*potency, 0, POTENCY_MULTIPLIER_VHIGH*potency) //Massive brute/tox damage
 
 /datum/chem_property/positive/neogenetic
 	name = PROPERTY_NEOGENETIC
@@ -46,14 +48,23 @@
 	starter = TRUE
 	value = 1
 
-/datum/chem_property/positive/neogenetic/process(mob/living/M, var/potency = 1, delta_time)
-	M.heal_limb_damage(0.5 * potency * delta_time, 0)
+/datum/chem_property/positive/neogenetic/process(mob/living/M, var/potency = 1)
+	M.heal_limb_damage(potency, 0)
+	if(potency > CREATE_MAX_TIER_1)
+		M.heal_limb_damage(potency * POTENCY_MULTIPLIER_LOW, 0)
 
 /datum/chem_property/positive/neogenetic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(0.5 * potency * delta_time, BURN)
 
-/datum/chem_property/positive/neogenetic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0, 2 * potency * delta_time, potency * delta_time)
+/datum/chem_property/positive/neogenetic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(0, POTENCY_MULTIPLIER_VHIGH * potency, POTENCY_MULTIPLIER_MEDIUM * potency)
+
+/datum/chem_property/positive/neogenetic/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!isXeno(M))
+		return
+	var/mob/living/carbon/Xenomorph/X = M
+	if(potency > 2) //heals at levels 5+
+		X.gain_health(potency * volume * POTENCY_MULTIPLIER_LOW)
 
 /datum/chem_property/positive/repairing
 	name = PROPERTY_REPAIRING
@@ -69,13 +80,22 @@
 	var/mob/living/carbon/human/C = M
 	var/obj/limb/L = pick(C.limbs)
 	if(L && (L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
-		L.heal_damage(potency * delta_time, potency * delta_time, TRUE)
+		L.heal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, POTENCY_MULTIPLIER_MEDIUM * potency,0,1)
 
-/datum/chem_property/positive/repairing/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/repairing/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/positive/repairing/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2 * potency * delta_time, TOX)
+/datum/chem_property/positive/repairing/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, TOX)
+
+/datum/chem_property/positive/repairing/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!ishuman(M) || method != TOUCH) //heals when sprayed on limbs
+		return
+	var/mob/living/carbon/human/H
+	for(var/obj/limb/T in H.limbs)
+		if(!(T.status & LIMB_ROBOT))
+			continue
+		T.heal_damage(potency * volume,potency * volume,0,1)
 
 /datum/chem_property/positive/hemogenic
 	name = PROPERTY_HEMOGENIC
@@ -88,17 +108,17 @@
 		return
 	var/mob/living/carbon/C = M
 	C.blood_volume = min(C.blood_volume+potency,BLOOD_VOLUME_MAXIMUM+100)
-	if(potency > 3 && C.blood_volume > BLOOD_VOLUME_MAXIMUM && !isYautja(M)) //Too many red blood cells thickens the blood and leads to clotting, doesn't impact Yautja
-		M.take_limb_damage(0.5 * potency * delta_time)
-		M.apply_damage(potency * delta_time, OXY)
+	if(potency > POTENCY_MAX_TIER_1 && C.blood_volume > BLOOD_VOLUME_MAXIMUM && !isYautja(M)) //Too many red blood cells thickens the blood and leads to clotting, doesn't impact Yautja
+		M.take_limb_damage(potency)
+		M.apply_damage(POTENCY_MULTIPLIER_MEDIUM*potency, OXY)
 		M.reagent_move_delay_modifier += potency
 		M.recalculate_move_delay = TRUE
 
-/datum/chem_property/positive/hemogenic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/hemogenic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/positive/hemogenic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.nutrition = max(M.nutrition - 2.5 * potency * delta_time, 0)
+/datum/chem_property/positive/hemogenic/process_critical(mob/living/M, var/potency = 1)
+	M.nutrition = max(M.nutrition - POTENCY_MULTIPLIER_VHIGH*potency, 0)
 
 /datum/chem_property/positive/nervestimulating
 	name = PROPERTY_NERVESTIMULATING
@@ -106,25 +126,32 @@
 	description = "Increases neuron communication speed across synapses resulting in improved reaction time, awareness and muscular control."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_STIMULANT
+	value = 3
 
-/datum/chem_property/positive/nervestimulating/process(mob/living/M, var/potency = 1, delta_time)
-	M.AdjustKnockedout(-0.5 * potency * delta_time)
-	M.AdjustStunned(-0.5 * potency * delta_time)
-	M.AdjustKnockeddown(-0.5 * potency * delta_time)
-	M.AdjustStunned(-0.25 * potency* delta_time)
-	if(potency > 2)
-		M.stuttering = max(M.stuttering - potency * delta_time, 0)
-		M.confused = max(M.confused - potency * delta_time, 0)
-		M.eye_blurry = max(M.eye_blurry - potency * delta_time, 0)
-		M.drowsyness = max(M.drowsyness - potency * delta_time, 0)
-		M.dizziness = max(M.dizziness - potency * delta_time, 0)
-		M.jitteriness = max(M.jitteriness - potency * delta_time, 0)
+/datum/chem_property/positive/nervestimulating/process(mob/living/M, var/potency = 1)
+	M.AdjustKnockedout(potency*-1)
+	M.AdjustStunned(potency*-1)
+	M.AdjustKnockeddown(potency*-1)
+	M.AdjustStunned(-0.5*potency)
+	if(potency > CREATE_MAX_TIER_1)
+		M.stuttering = max(M.stuttering - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+		M.confused = max(M.confused - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+		M.eye_blurry = max(M.eye_blurry - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+		M.drowsyness = max(M.drowsyness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+		M.dizziness = max(M.dizziness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
+		M.jitteriness = max(M.jitteriness - POTENCY_MULTIPLIER_MEDIUM * potency, 0)
 
-/datum/chem_property/positive/nervestimulating/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/nervestimulating/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM*potency, TOX)
 
-/datum/chem_property/positive/nervestimulating/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0.5 * potency* delta_time, 0.5 * potency * delta_time, 1.5 * potency * delta_time)
+/datum/chem_property/positive/nervestimulating/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(potency, potency, POTENCY_MULTIPLIER_HIGH*potency)
+
+/datum/chem_property/positive/nervestimulating/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(isXenoOrHuman(M) && potency > POTENCY_MAX_TIER_1) //can stim on touch at level 7+
+		M.SetKnockeddown(0)
+		M.SetStunned(0)
+		M.SetDazed(0)
 
 /datum/chem_property/positive/musclestimulating
 	name = PROPERTY_MUSCLESTIMULATING
@@ -132,13 +159,12 @@
 	description = "Stimulates neuromuscular junctions increasing the force of muscle contractions, resulting in increased strength. High doses might exhaust the cardiac muscles."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_STIMULANT
-	value = 1
 
-/datum/chem_property/positive/musclestimulating/process(mob/living/M, var/potency = 1, delta_time)
-	M.reagent_move_delay_modifier -= 0.25 * potency
+/datum/chem_property/positive/musclestimulating/process(mob/living/M, var/potency = 1)
+	M.reagent_move_delay_modifier -= POTENCY_MULTIPLIER_VLOW * potency
 	M.recalculate_move_delay = TRUE
-	M.nutrition = max (0, M.nutrition - 0.5 * HUNGER_FACTOR * delta_time)
-	if(prob(5 * delta_time))
+	M.nutrition = max (0, M.nutrition - 0.5 * HUNGER_FACTOR)
+	if(prob(10))
 		M.emote(pick("twitch","blink_r","shiver"))
 
 /datum/chem_property/positive/musclestimulating/process_overdose(mob/living/M, var/potency = 1, delta_time)
@@ -148,6 +174,11 @@
 
 /datum/chem_property/positive/musclestimulating/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.take_limb_damage(0.5 * potency * delta_time)
+
+/datum/chem_property/positive/musclestimulating/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency = 1)
+	if(!isXenoOrHuman(M))
+		return
+	M.AddComponent(/datum/component/speed_modifier, volume, TRUE, AMOUNT_PER_TIME(1, potency SECONDS), potency*volume) //Long-lasting speed for beans, stamina for humans
 
 /datum/chem_property/positive/painkilling
 	name = PROPERTY_PAINKILLING
@@ -176,26 +207,27 @@
 	M.hallucination = max(M.hallucination, potency) //Hallucinations and tox damage
 	M.apply_damage(0.5 *  potency * delta_time, TOX)
 
-/datum/chem_property/positive/painkilling/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_internal_damage(1.5 * potency * delta_time, "liver")
-	M.apply_damage(0.5 * potency * delta_time, BRAIN)
-	M.apply_damage(1.5 * delta_time, OXY)
+/datum/chem_property/positive/painkilling/process_critical(mob/living/M, var/potency = 1)
+	M.apply_internal_damage(POTENCY_MULTIPLIER_HIGH * potency, "liver")
+	M.apply_damage(potency, BRAIN)
+	M.apply_damage(3, OXY)
 
 /datum/chem_property/positive/hepatopeutic
 	name = PROPERTY_HEPATOPEUTIC
 	code = "HPP"
 	description = "Treats deteriorated hepatocytes and damaged tissues in the liver, restoring organ functions."
 	rarity = PROPERTY_UNCOMMON
+	value = 1
 
 /datum/chem_property/positive/hepatopeutic/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(-0.25 * potency * delta_time, "liver")
+	M.apply_internal_damage(-(POTENCY_MULTIPLIER_LOW * potency), "liver")
 
 /datum/chem_property/positive/hepatopeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(potency * delta_time, "liver")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, "liver")
 
 /datum/chem_property/positive/hepatopeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(2.5 * potency * delta_time, TOX)
@@ -205,16 +237,17 @@
 	code = "NPP"
 	description = "Heals damaged and deteriorated podocytes in the kidney, restoring organ functions."
 	rarity = PROPERTY_UNCOMMON
+	value = 1
 
 /datum/chem_property/positive/nephropeutic/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(-0.25 * potency * delta_time, "kidneys")
+	M.apply_internal_damage(-(POTENCY_MULTIPLIER_LOW * potency), "kidneys")
 
 /datum/chem_property/positive/nephropeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(potency * delta_time, "kidneys")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, "kidneys")
 
 /datum/chem_property/positive/nephropeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(2.5 * potency * delta_time, TOX)
@@ -224,45 +257,48 @@
 	code = "PNP"
 	description = "Mends the interstitium tissue of the alveoli restoring respiratory functions in the lungs."
 	rarity = PROPERTY_UNCOMMON
+	value = 1
 
 /datum/chem_property/positive/pneumopeutic/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(-0.25 * potency * delta_time, "lungs")
+	M.apply_internal_damage(-(POTENCY_MULTIPLIER_LOW * potency), "lungs")
 
 /datum/chem_property/positive/pneumopeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(potency * delta_time, "lungs")
+	M.apply_internal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, "lungs")
 
-/datum/chem_property/positive/pneumopeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2.5 * potency * delta_time, OXY)
+/datum/chem_property/positive/pneumopeutic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH*potency, OXY)
 
 /datum/chem_property/positive/oculopeutic
 	name = PROPERTY_OCULOPEUTIC
 	code = "OCP"
 	description = "Restores sensory capabilities of photoreceptive cells in the eyes returning lost vision."
 	rarity = PROPERTY_COMMON
+	value = 1
 
 /datum/chem_property/positive/oculopeutic/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
 		return
-	M.apply_internal_damage(-0.5 * potency * delta_time, "eyes")
-	M.eye_blurry = max(M.eye_blurry - 2.5 * potency * delta_time, 0)
-	M.eye_blind = max(M.eye_blind - 2.5 * potency * delta_time, 0)
+	M.apply_internal_damage(-potency, "eyes")
+	M.eye_blurry = max(M.eye_blurry-POTENCY_MULTIPLIER_VHIGH*potency , 0)
+	M.eye_blind = max(M.eye_blind-POTENCY_MULTIPLIER_VHIGH*potency , 0)
 
-/datum/chem_property/positive/oculopeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/oculopeutic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/positive/oculopeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0.5 * potency * delta_time, 0.5 * potency * delta_time, 1.5 * potency * delta_time)
-	M.apply_damage(0.5 * potency * delta_time, BRAIN)
+/datum/chem_property/positive/oculopeutic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(potency, potency, POTENCY_MULTIPLIER_HIGH * potency)
+	M.apply_damage(potency, BRAIN)
 
 /datum/chem_property/positive/cardiopeutic
 	name = PROPERTY_CARDIOPEUTIC
 	code = "CDP"
 	description = "Regenerates damaged cardiomyocytes and recovers a correct cardiac cycle and heart functionality."
 	rarity = PROPERTY_UNCOMMON
+	value = 1
 
 /datum/chem_property/positive/cardiopeutic/on_delete(mob/living/M)
 	..()
@@ -272,10 +308,10 @@
 /datum/chem_property/positive/cardiopeutic/process(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M) || !(..()))
 		return
-	M.apply_internal_damage(-0.25 * potency * delta_time, "heart")
+	M.apply_internal_damage(-(POTENCY_MULTIPLIER_LOW * potency), "heart")
 
-/datum/chem_property/positive/cardiopeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, OXY)
+/datum/chem_property/positive/cardiopeutic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM*potency, OXY)
 
 /datum/chem_property/positive/cardiopeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	if(!(..()))
@@ -289,15 +325,15 @@
 	description = "Rebuilds damaged and broken neurons in the central nervous system re-establishing brain functionality."
 	rarity = PROPERTY_COMMON
 
-/datum/chem_property/positive/neuropeutic/process(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(-1.5 * potency * delta_time, BRAIN)
+/datum/chem_property/positive/neuropeutic/process(mob/living/M, var/potency = 1)
+	M.apply_damage(-POTENCY_MULTIPLIER_HIGH * potency, BRAIN)
 
 /datum/chem_property/positive/neuropeutic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(0.5 * potency * delta_time, TOX)
 
-/datum/chem_property/positive/neuropeutic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(1.5 * potency * delta_time, BRAIN)
-	M.AdjustStunned(0.5 * potency * delta_time)
+/datum/chem_property/positive/neuropeutic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_HIGH * potency, BRAIN)
+	M.AdjustStunned(potency)
 
 /datum/chem_property/positive/bonemending
 	name = PROPERTY_BONEMENDING
@@ -331,8 +367,8 @@
 				L.start_processing()
 				to_chat(M, SPAN_NOTICE("You feel the bones in your [L.display_name] starting to knit together."))
 
-/datum/chem_property/positive/bonemending/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(potency * delta_time)
+/datum/chem_property/positive/bonemending/process_overdose(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_MEDIUM*potency)
 
 /datum/chem_property/positive/bonemending/process_critical(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
@@ -356,18 +392,18 @@
 	var/obj/limb/L = pick(H.limbs)
 	if(L && prob(5 * potency * delta_time))
 		if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
-			L.take_damage(0, 2*potency)
+			L.take_damage(0, potency)
 			return
 		if(L.implants && L.implants.len > 0)
 			var/obj/implanted_object = pick(L.implants)
 			if(implanted_object)
 				L.implants -= implanted_object
 
-/datum/chem_property/positive/fluxing/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(potency * delta_time, 0, potency * delta_time)
+/datum/chem_property/positive/fluxing/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_MEDIUM*potency, 0, potency)
 
-/datum/chem_property/positive/fluxing/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(2 * potency * delta_time, 0, 2 * potency * delta_time) //Mixed brute/tox damage
+/datum/chem_property/positive/fluxing/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_MEDIUM*potency, 0, POTENCY_MULTIPLIER_MEDIUM*potency) //Mixed brute/tox damage
 
 /datum/chem_property/positive/neurocryogenic
 	name = PROPERTY_NEUROCRYOGENIC
@@ -395,6 +431,11 @@
 	H.revive_grace_period += 2.5 SECONDS * potency * delta_time
 	return TRUE
 
+/datum/chem_property/positive/neurocryogenic/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency = 1)
+	if(!isXenoOrHuman(M))
+		return
+	M.AddComponent(/datum/component/speed_modifier, potency * volume * 0.5) //Brainfreeze
+
 /datum/chem_property/positive/antiparasitic
 	name = PROPERTY_ANTIPARASITIC
 	code = "APS"
@@ -409,8 +450,8 @@
 		var/obj/item/alien_embryo/A = content
 		if(A && istype(A))
 			if(A.counter > 0)
-				A.counter -= 0.5 * potency * delta_time
-				H.take_limb_damage(0, 0.1 * potency * delta_time)
+				A.counter = A.counter - potency
+				H.take_limb_damage(0,POTENCY_MULTIPLIER_MEDIUM*potency)
 			else
 				A.stage--
 				if(A.stage <= 0)//if we reach this point, the embryo dies and the occupant takes a nasty amount of acid damage
@@ -420,17 +461,17 @@
 				else
 					A.counter = 90
 
-/datum/chem_property/positive/antiparasitic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/antiparasitic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/positive/antiparasitic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(2 * potency * delta_time, TOX)
+/datum/chem_property/positive/antiparasitic/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_VHIGH*potency, TOX)
 
 /datum/chem_property/positive/organstabilize
 	name = PROPERTY_ORGANSTABILIZE
 	code = "OGS"
 	description = "Stabilizes internal organ damage, stopping internal damage symptoms."
-	rarity = PROPERTY_COMMON
+	rarity = PROPERTY_DISABLED
 	value = 2
 
 /datum/chem_property/positive/organstabilize/process(mob/living/M, var/potency = 1, delta_time)
@@ -442,8 +483,8 @@
 /datum/chem_property/positive/organstabilize/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.apply_damage(0.5 * potency * delta_time, BRUTE)
 
-/datum/chem_property/positive/organstabilize/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(1.5 * potency * delta_time, 1.5 * potency * delta_time, 1.5 * potency * delta_time)
+/datum/chem_property/positive/organstabilize/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(POTENCY_MULTIPLIER_HIGH * potency, POTENCY_MULTIPLIER_HIGH * potency, POTENCY_MULTIPLIER_HIGH * potency)
 
 /datum/chem_property/positive/electrogenetic
 	name = PROPERTY_ELECTROGENETIC
@@ -456,18 +497,10 @@
 /datum/chem_property/positive/electrogenetic/trigger(var/A)
 	if(isliving(A))
 		var/mob/living/M = A
-		M.apply_damage(-4*level, BRUTE)
-		M.apply_damage(-4*level, BURN)
-		M.apply_damage(-4*level, TOX)
+		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BRUTE)
+		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BURN)
+		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, TOX)
 		M.updatehealth()
-
-/datum/chem_property/positive/electrogenetic/reset_reagent()
-	holder.flags = initial(holder.flags)
-	..()
-
-/datum/chem_property/positive/electrogenetic/update_reagent()
-	holder.flags |= REAGENT_NOT_INGESTIBLE
-	..()
 
 /datum/chem_property/positive/defibrillating
 	name = PROPERTY_DEFIBRILLATING
@@ -492,7 +525,7 @@
 		return
 
 	M.pain.apply_pain(PROPERTY_DEFIBRILLATING_PAIN_OD)
-	M.apply_damage(potency * delta_time, OXY)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM*potency, OXY)
 
 /datum/chem_property/positive/defibrillating/process_critical(mob/living/M, var/potency = 1, delta_time)
 	if(!ishuman(M))
@@ -508,6 +541,13 @@
 		to_chat(H, SPAN_NOTICE("You feel your heart struggling as you suddenly feel a spark, making it desperately try to continue pumping."))
 		playsound_client(H.client, 'sound/effects/Heart Beat Short.ogg', 35)
 		addtimer(CALLBACK(H, /mob/living/carbon/human.proc/handle_revive), 50, TIMER_UNIQUE)
+	else if (potency > POTENCY_MAX_TIER_1 && H.check_tod() && H.is_revivable() && H.health < HEALTH_THRESHOLD_DEAD) //Will heal if level is 7 or greater
+		to_chat(H, SPAN_NOTICE("You feel a faint spark in your chest."))
+		H.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, BRUTE)
+		H.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, BURN)
+		H.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, TOX)
+		H.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, CLONE)
+		H.apply_damage(-H.getOxyLoss(), OXY)
 	return TRUE
 
 /datum/chem_property/positive/hyperdensificating
@@ -529,9 +569,9 @@
 	if(prob(5 * delta_time))
 		to_chat(M, SPAN_NOTICE("Your body feels incredibly tense."))
 
-/datum/chem_property/positive/hyperdensificating/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.reagent_move_delay_modifier += 2*potency
-	if(prob(5 * delta_time))
+/datum/chem_property/positive/hyperdensificating/process_overdose(mob/living/M, var/potency = 1)
+	M.reagent_move_delay_modifier += POTENCY_MULTIPLIER_MEDIUM*potency
+	if(prob(10))
 		to_chat(M, SPAN_NOTICE("It is really hard to move your body."))
 
 /datum/chem_property/positive/hyperdensificating/process_critical(mob/living/M, var/potency = 1, delta_time)
@@ -561,8 +601,8 @@
 		return
 	M.apply_internal_damage(0.5 * potency * delta_time, "liver")
 
-/datum/chem_property/positive/neuroshielding/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, BRAIN)
+/datum/chem_property/positive/neuroshielding/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_MEDIUM*potency, BRAIN)
 
 /datum/chem_property/positive/antiaddictive
 	name = PROPERTY_ANTIADDICTIVE
@@ -573,11 +613,11 @@
 
 /datum/chem_property/positive/antiaddictive/process(mob/living/M, var/potency = 1, delta_time)
 	for(var/datum/disease/addiction/D in M.viruses)
-		if(potency >= 4)
+		if(potency > POTENCY_MAX_TIER_1)
 			D.cure()
 			return
-		D.withdrawal_progression -= potency * delta_time
-		D.addiction_progression -= potency * delta_time
+		D.withdrawal_progression -= POTENCY_MULTIPLIER_MEDIUM*potency
+		D.addiction_progression -= POTENCY_MULTIPLIER_MEDIUM*potency
 		if(D.addiction_progression < potency)
 			D.cure()
 
@@ -643,6 +683,20 @@
 	durationmod_per_level = 0.2
 	radiusmod_per_level = 0.01
 
+/datum/chem_property/positive/fire/fueling/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency = 1)
+	var/mob/living/L = M
+	if(istype(L) && method == TOUCH)//makes you more flammable if sprayed/splashed on you
+		L.adjust_fire_stacks(volume / (2/potency))
+
+/datum/chem_property/positive/fire/fueling/reaction_turf(var/turf/T, var/volume, var/potency = 1)
+	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
+
+/datum/chem_property/positive/fire/fueling/reaction_obj(obj/O, volume, potency)
+	var/turf/the_turf = get_turf(O) //tries to splash fuel on object's turf
+	if(!the_turf)
+		return
+	new /obj/effect/decal/cleanable/liquid_fuel(the_turf, volume)
+
 /datum/chem_property/positive/fire/oxidizing
 	name = PROPERTY_OXIDIZING
 	code = "OXI"
@@ -655,6 +709,13 @@
 	intensitymod_per_level = 0.2
 	durationmod_per_level = -0.1
 	radiusmod_per_level = -0.01
+
+/datum/chem_property/positive/fire/oxidizing/reaction_mob(var/mob/M, var/method = TOUCH, var/volume, var/potency = 1)
+	var/mob/living/L = M
+	if(istype(L) && method == TOUCH)//Oxidizing 6+ makes a fire, otherwise it just adjusts fire stacks
+		L.adjust_fire_stacks(max(L.fire_stacks, volume * potency))
+		if(potency > 4)
+			L.IgniteMob(TRUE)
 
 /datum/chem_property/positive/fire/flowing
 	name = PROPERTY_FLOWING
@@ -689,6 +750,62 @@
 	holder.power += level
 	holder.falloff_modifier += -3 / level
 	..()
+
+//properties with combat uses
+/datum/chem_property/positive/disrupting
+	name = PROPERTY_DISRUPTING
+	code = "DSR"
+	description = "Disrupts certain neurological processes related to communication in animals."
+	rarity = PROPERTY_UNCOMMON
+	category = PROPERTY_TYPE_TOXICANT
+
+/datum/chem_property/positive/disrupting/process(mob/living/M, var/potency = 1)
+	to_chat(M, SPAN_NOTICE("Your mind feels oddly... quiet."))
+
+/datum/chem_property/positive/disrupting/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_internal_damage(potency, "brain")
+
+/datum/chem_property/positive/disrupting/process_critical(mob/living/M, var/potency = 1)
+	M.KnockOut(potency)
+
+/datum/chem_property/positive/disrupting/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!isXeno(M))
+		return
+	var/mob/living/carbon/Xenomorph/X = M
+	X.interference += (volume * potency)
+
+/datum/chem_property/positive/neutralizing
+	name = PROPERTY_NEUTRALIZING
+	code = "NEU"
+	description = "Neutralizes certain reactive chemicals and plasmas on contact. Unsafe to administer intravenously."
+	rarity = PROPERTY_UNCOMMON
+	category = PROPERTY_TYPE_IRRITANT
+
+/datum/chem_property/positive/neutralizing/process(mob/living/M, var/potency = 1)
+	M.apply_damages(0, potency, potency * POTENCY_MULTIPLIER_LOW)
+
+/datum/chem_property/positive/neutralizing/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damages(0, POTENCY_MULTIPLIER_MEDIUM * potency, potency)
+
+/datum/chem_property/positive/neutralizing/process_critical(mob/living/M, var/potency = 1)
+	M.apply_internal_damage(potency, "liver")
+
+/datum/chem_property/positive/neutralizing/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!isliving(M))
+		return
+	var/mob/living/L = M
+	L.ExtinguishMob() //Extinguishes mobs on contact
+	if(isXeno(L))
+		var/mob/living/carbon/Xenomorph/X = M
+		X.plasma_stored = max(X.plasma_stored - POTENCY_MULTIPLIER_VHIGH * POTENCY_MULTIPLIER_VHIGH * potency, 0)
+
+/datum/chem_property/positive/neutralizing/reaction_turf(var/turf/T, var/volume, var/potency)
+	if(!istype(T))
+		return
+	for(var/obj/flamer_fire/F in T) //Extinguishes fires and acid
+		qdel(F)
+	for(var/obj/effect/xenomorph/acid/A in T)
+		qdel(A)
 
 //PROPERTY_DISABLED (in random generation)
 /datum/chem_property/positive/cardiostabilizing
@@ -725,6 +842,13 @@
 	if(prob(5 * delta_time))
 		M.emote(pick("twitch","blink_r","shiver"))
 
+/datum/chem_property/positive/cardiostabilizing/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!isXeno(M))
+		return
+	var/mob/living/carbon/Xenomorph/X = M
+	if(X.health < 0) //heals out of crit with enough potency/volume, otherwise reduces crit
+		X.gain_health(min(potency * volume * 0.5, -X.health + 1))
+
 /datum/chem_property/positive/aiding
 	name = PROPERTY_AIDING
 	code = "AID"
@@ -760,20 +884,20 @@
 	value = 1
 	max_level = 6
 
-/datum/chem_property/positive/oxygenating/process(mob/living/M, var/potency = 1, delta_time)
-	if(potency >= 2)
-		holder.holder.remove_reagent("lexorin", 0.5 * potency * delta_time)
-	if(potency >= 3)
+/datum/chem_property/positive/oxygenating/process(mob/living/M, var/potency = 1)
+	if(potency >= CREATE_MAX_TIER_1)
+		holder.holder.remove_reagent("lexorin", 1 * potency)
+	if(potency >= POTENCY_MAX_TIER_1)
 		M.apply_damage(-M.getOxyLoss(), OXY)
 	else
-		M.apply_damage(-0.5 * potency * delta_time, OXY)
+		M.apply_damage(-1 * potency, OXY)
 
 
-/datum/chem_property/positive/oxygenating/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(0.25 * potency * delta_time, TOX) //Mixed brute/tox damage
+/datum/chem_property/positive/oxygenating/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(POTENCY_MULTIPLIER_LOW * potency, TOX) //Mixed brute/tox damage
 
-/datum/chem_property/positive/oxygenating/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damages(0.5 * potency * delta_time, 0, potency * delta_time) //Massive brute/tox damage
+/datum/chem_property/positive/oxygenating/process_critical(mob/living/M, var/potency = 1)
+	M.apply_damages(potency, 0, POTENCY_MULTIPLIER_MEDIUM * potency) //Massive brute/tox damage
 
 /datum/chem_property/positive/anticarcinogenic
 	name = PROPERTY_ANTICARCINOGENIC
@@ -786,8 +910,8 @@
 /datum/chem_property/positive/anticarcinogenic/process(mob/living/M, var/potency = 1, delta_time)
 	M.adjustCloneLoss(-0.5 * potency * delta_time)
 
-/datum/chem_property/positive/anticarcinogenic/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.apply_damage(potency * delta_time, TOX)
+/datum/chem_property/positive/anticarcinogenic/process_overdose(mob/living/M, var/potency = 1)
+	M.apply_damage(potency, TOX)
 
-/datum/chem_property/positive/anticarcinogenic/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(potency * delta_time) //Hyperactive apoptosis
+/datum/chem_property/positive/anticarcinogenic/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_MEDIUM * potency)//Hyperactive apoptosis

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -36,13 +36,13 @@
 	rarity = PROPERTY_LEGENDARY
 	category = PROPERTY_TYPE_MEDICINE
 
-/datum/chem_property/special/hypergenetic/process(mob/living/M, var/potency = 1, delta_time)
-	M.heal_limb_damage(0.1 * potency * delta_time)
+/datum/chem_property/special/hypergenetic/process(mob/living/M, var/potency = 1)
+	M.heal_limb_damage(potency)
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/H = M
 	for(var/datum/internal_organ/O in H.internal_organs)
-		M.apply_internal_damage(-0.5 * potency * delta_time, O)
+		M.apply_internal_damage(-potency, O)
 
 /datum/chem_property/special/hypergenetic/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	M.adjustCloneLoss(potency * delta_time)
@@ -50,6 +50,16 @@
 /datum/chem_property/special/hypergenetic/process_critical(mob/living/M, var/potency = 1, delta_time)
 	M.take_limb_damage(1.5 * potency * delta_time, 1.5 * potency * delta_time)
 
+/datum/chem_property/special/hypergenetic/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
+	if(!isXenoOrHuman(M))
+		return
+	M.AddComponent(/datum/component/healing_reduction, -potency * volume * POTENCY_MULTIPLIER_LOW) //reduces heal reduction if present
+	if(ishuman(M)) //heals on contact with humans/xenos
+		var/mob/living/carbon/human/H = M
+		H.heal_limb_damage(potency * volume * POTENCY_MULTIPLIER_LOW)
+	if(isXeno(M)) //more effective on xenos to account for higher HP
+		var/mob/living/carbon/Xenomorph/X = M
+		X.gain_health(potency * volume)
 
 /datum/chem_property/special/organhealing
 	name = PROPERTY_ORGAN_HEALING
@@ -65,11 +75,11 @@
 	for(var/datum/internal_organ/O in H.internal_organs)
 		M.apply_internal_damage(-0.5 * potency * delta_time, O)
 
-/datum/chem_property/special/organhealing/process_overdose(mob/living/M, var/potency = 1, delta_time)
-	M.adjustCloneLoss(potency * delta_time)
+/datum/chem_property/special/organhealing/process_overdose(mob/living/M, var/potency = 1)
+	M.adjustCloneLoss(POTENCY_MULTIPLIER_MEDIUM * potency)
 
-/datum/chem_property/special/organhealing/process_critical(mob/living/M, var/potency = 1, delta_time)
-	M.take_limb_damage(1.5 * potency * delta_time, 1.5 * potency * delta_time)
+/datum/chem_property/special/organhealing/process_critical(mob/living/M, var/potency = 1)
+	M.take_limb_damage(POTENCY_MULTIPLIER_HIGH * potency, POTENCY_MULTIPLIER_HIGH * potency)
 
 /datum/chem_property/special/DNA_Disintegrating
 	name = PROPERTY_DNA_DISINTEGRATING
@@ -79,8 +89,8 @@
 	category = PROPERTY_TYPE_TOXICANT|PROPERTY_TYPE_ANOMALOUS
 	value = 16
 
-/datum/chem_property/special/DNA_Disintegrating/process(mob/living/M, var/potency = 1, delta_time)
-	M.adjustCloneLoss(5 * potency * delta_time)
+/datum/chem_property/special/DNA_Disintegrating/process(mob/living/M, var/potency = 1)
+	M.adjustCloneLoss(POTENCY_MULTIPLIER_EXTREME * potency)
 	if(ishuman(M) && M.cloneloss >= 190)
 		var/mob/living/carbon/human/H = M
 		H.contract_disease(new /datum/disease/xeno_transformation(0),1) //This is the real reason PMCs are being sent to retrieve it.
@@ -222,7 +232,7 @@
 	var/mob/living/carbon/human/H = M
 	if(H.viruses)
 		for(var/datum/disease/D in H.viruses)
-			if(potency >= 2)
+			if(potency >= CREATE_MAX_TIER_1)
 				D.cure()
 				zs.remove_from_revive(H)
 			else
@@ -244,8 +254,8 @@
 	M.reagents.remove_all_type(/datum/reagent/toxin, 2.5*REM * delta_time, 0, 1)
 	M.setCloneLoss(0)
 	M.setOxyLoss(0)
-	M.heal_limb_damage(2.5 * potency * delta_time, 2.5 * potency * delta_time)
-	M.apply_damage(-2.5 * potency * delta_time, TOX)
+	M.heal_limb_damage(POTENCY_MULTIPLIER_VHIGH * potency, POTENCY_MULTIPLIER_VHIGH * potency)
+	M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * potency, TOX)
 	M.hallucination = 0
 	M.setBrainLoss(0)
 	M.disabilities = 0
@@ -345,9 +355,10 @@
 	name = PROPERTY_FIRE_PENETRATING
 	code = "PTR"
 	description = "Gives the chemical a unique, anomalous combustion chemistry, causing the flame to react with flame-resistant material and obliterate through it."
-	rarity = PROPERTY_ADMIN
+	rarity = PROPERTY_LEGENDARY
 	category = PROPERTY_TYPE_REACTANT|PROPERTY_TYPE_ANOMALOUS
-	value = 666
+	value = 8
+	max_level = 1
 
 /datum/chem_property/special/firepenetrating/reset_reagent()
 	holder.fire_penetrating = initial(holder.fire_penetrating)

--- a/code/modules/reagents/chemistry_reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry_reagents/alcohol.dm
@@ -67,13 +67,6 @@
 			to_chat(usr, "It wasn't enough...")
 	return
 
-/datum/reagent/ethanol/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with ethanol isn't quite as good as fuel.
-	if(!istype(M, /mob/living))
-		return
-	if(method == TOUCH)
-		M.adjust_fire_stacks(volume / 15)
-		return
-
 /datum/reagent/ethanol/beer
 	name = "Beer"
 	id = "beer"

--- a/code/modules/reagents/chemistry_reagents/food.dm
+++ b/code/modules/reagents/chemistry_reagents/food.dm
@@ -18,67 +18,73 @@
 	name = "Egg"
 	id = "egg"
 	description = "The contents of an egg. Salmonella not included."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/tofu
 	name = "Tofu"
 	id = "tofu"
 	description = "Meat substitute."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/cheese
 	name = "Cheese"
 	id = "cheese"
 	description = "This used to be milk."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/meat
 	name = "Meat Protein"
 	id = "meatprotein"
 	description = "Proteins found in various types of meat."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/meat/fish
 	name = "Fish Meat"
 	id = "fish"
 	description = "It used to swim."
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/grown
 	name = "Plant Matter"
 	id = "plantmatter"
 	description = "Some sort of plant."
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/grown/vegetable
 	name = "Vegetable"
 	id = "vegetable"
 	description = "Some sort of vegetable."
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/grown/fruit
 	name = "Fruit"
 	id = "fruit"
 	description = "Some sort of fruit."
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/grown/mushroom
 	name = "Mushroom"
 	id = "mushroom"
 	description = "Some sort of fungus."
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/dough
 	name = "Dough"
 	id = "dough"
 	description = "Wet flour."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/dough/bread
 	name = "Bread"
 	id = "bread"
 	description = "Cooked bread."
-	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nutriment/dough/noodles
 	name = "Noodles"
 	id = "noodles"
 	description = "Cooked noodles."
+	flags = REAGENT_NO_GENERATION
 
 
 /datum/reagent/lipozine
@@ -220,6 +226,7 @@
 	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#FF00FF" // rgb: 255, 0, 255
 	properties = list(PROPERTY_NUTRITIOUS = 2)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/cornoil
 	name = "Corn Oil"
@@ -250,6 +257,7 @@
 	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	properties = list(PROPERTY_NUTRITIOUS = 2)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/hot_ramen
 	name = "Hot Ramen"
@@ -259,6 +267,7 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	properties = list(PROPERTY_NUTRITIOUS = 2, PROPERTY_HYPERTHERMIC = 1)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/hell_ramen
 	name = "Hell Ramen"
@@ -268,6 +277,7 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	properties = list(PROPERTY_NUTRITIOUS = 2, PROPERTY_HYPERTHERMIC = 4)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/rice
 	name = "Rice"
@@ -293,3 +303,4 @@
 	description = "Honey is a natural sweet, viscous food substance composed of mainly fructose and glucose."
 	color = "#FFFF00"
 	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -292,8 +292,8 @@
 	overdose_critical = LOWM_REAGENTS_OVERDOSE_CRITICAL
 	custom_metabolism = AMOUNT_PER_TIME(1, 5 SECONDS)
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_PAINKILLING = 1.5, PROPERTY_ELECTROGENETIC = 4)
-	flags = REAGENT_TYPE_MEDICAL | REAGENT_SCANNABLE | REAGENT_NOT_INGESTIBLE
+	properties = list(PROPERTY_PAINKILLING = 1.5, PROPERTY_ELECTROGENETIC = 4, PROPERTY_INTRAVENOUS = 1)
+	flags = REAGENT_TYPE_MEDICAL | REAGENT_SCANNABLE
 
 /datum/reagent/medical/ultrazine
 	name = "Ultrazine"
@@ -306,7 +306,7 @@
 	overdose_critical = LOWM_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_MUSCLESTIMULATING = 40, PROPERTY_ADDICTIVE = 8)
-	flags = REAGENT_TYPE_MEDICAL
+	flags = REAGENT_TYPE_MEDICAL | REAGENT_NO_GENERATION
 
 /datum/reagent/medical/stimulant
 	name = "Stimulant"
@@ -319,7 +319,7 @@
 	overdose_critical = LOWH_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_UNKNOWN = 1)
-	flags = REAGENT_TYPE_MEDICAL
+	flags = REAGENT_TYPE_MEDICAL | REAGENT_NO_GENERATION
 
 /datum/reagent/medical/cryoxadone
 	name = "Cryoxadone"

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -482,21 +482,6 @@
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_FUELING = 5, PROPERTY_OXIDIZING = 3, PROPERTY_VISCOUS = 4, PROPERTY_TOXIC = 1)
 
-/datum/reagent/fuel/reaction_obj(var/obj/O, var/volume)
-	var/turf/the_turf = get_turf(O)
-	if(!the_turf)
-		return //No sense trying to start a fire if you don't have a turf to set on fire. --NEO
-	new /obj/effect/decal/cleanable/liquid_fuel(the_turf, volume)
-
-/datum/reagent/fuel/reaction_turf(var/turf/T, var/volume)
-	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
-
-/datum/reagent/fuel/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with welding fuel to make them easy to ignite!
-	if(!istype(M, /mob/living))
-		return
-	if(method == TOUCH)
-		M.adjust_fire_stacks(volume / 10)
-
 /datum/reagent/space_cleaner
 	name = "Space cleaner"
 	id = "cleaner"
@@ -584,6 +569,7 @@
 	burncolormod = 2
 	chemclass = CHEM_CLASS_RARE
 	custom_metabolism = AMOUNT_PER_TIME(1, 200 SECONDS)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/nanites
 	name = "Nanomachines"
@@ -804,19 +790,13 @@
 	chemfiresupp = TRUE
 	burncolor = "#ff9300"
 	chemclass = CHEM_CLASS_UNCOMMON
-	properties = list(PROPERTY_CORROSIVE = 8, PROPERTY_TOXIC = 6, PROPERTY_OXIDIZING = 8)
+	properties = list(PROPERTY_CORROSIVE = 8, PROPERTY_TOXIC = 6, PROPERTY_OXIDIZING = 9)
 
 /datum/reagent/chlorinetrifluoride/on_mob_life(var/mob/living/M) // Not a good idea, instantly messes you up from the inside out.
 	. = ..()
 	M.adjust_fire_stacks(max(M.fire_stacks, 15))
 	M.IgniteMob(TRUE)
 	to_chat(M, SPAN_DANGER("It burns! It burns worse than you could ever have imagined!"))
-
-/datum/reagent/chlorinetrifluoride/reaction_mob(var/mob/M, var/method = TOUCH, var/volume) // Spilled on you? Not good either, but not /as/ bad.
-	var/mob/living/L = M
-	if(istype(L))
-		L.adjust_fire_stacks(max(L.fire_stacks, 10))
-		L.IgniteMob(TRUE)
 
 /datum/reagent/methane
 	name = "Methane"

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -87,6 +87,7 @@
 	description = "Useful for dealing with undesirable customers."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"
@@ -95,6 +96,7 @@
 	reagent_state = LIQUID
 	color = "#003333" // rgb: 0, 51, 51
 	properties = list(PROPERTY_TOXIC = 2)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/toxin/zombiepowder
 	name = "Zombie Powder"
@@ -103,6 +105,7 @@
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
 	properties = list(PROPERTY_TOXIC = 1)
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
 	. = ..()
@@ -163,34 +166,7 @@
 	description = "A harmful toxic mixture used to kill plantlife. Very toxic to animals."
 	reagent_state = LIQUID
 	color = "#49002E" // rgb: 73, 0, 46
-
-/datum/reagent/toxin/plantbgone/reaction_obj(var/obj/O, var/volume)
-	if(istype(O,/obj/effect/alien/weeds/))
-		var/obj/effect/alien/weeds/alien_weeds = O
-		alien_weeds.take_damage(rand(15,35)) // Kills alien weeds pretty fast
-	else if(istype(O,/obj/effect/glowshroom)) // Even a small amount is enough to kill it
-		qdel(O)
-	else if(istype(O,/obj/effect/plantsegment))
-		if(prob(50)) qdel(O) // Kills kudzu too.
-	else if(istype(O,/obj/structure/machinery/portable_atmospherics/hydroponics))
-		var/obj/structure/machinery/portable_atmospherics/hydroponics/tray = O
-
-		if(tray.seed)
-			tray.health -= rand(30,50)
-			if(tray.pestlevel > 0)
-				tray.pestlevel -= 2
-			if(tray.weedlevel > 0)
-				tray.weedlevel -= 3
-			tray.toxins += 4
-			tray.check_level_sanity()
-			tray.update_icon()
-
-/datum/reagent/toxin/plantbgone/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
-	src = null
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		if(!C.wear_mask) // If not wearing a mask
-			C.apply_damage(2, TOX) // 4 toxic damage per application, doubled for some reason
+	properties = list(PROPERTY_TOXIC = 2)
 
 /datum/reagent/toxin/stoxin
 	name = "Soporific"
@@ -261,66 +237,7 @@
 	color = "#DB5008" // rgb: 219, 80, 8
 	var/meltprob = 10
 	chemclass = CHEM_CLASS_BASIC
-	properties = list(PROPERTY_TOXIC = 1, PROPERTY_CORROSIVE = 1)
-
-/datum/reagent/toxin/acid/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//magic numbers everywhere
-	if(!istype(M, /mob/living))
-		return
-	if(method == TOUCH)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(H.head)
-				if(prob(meltprob) && !H.head.unacidable)
-					to_chat(H, SPAN_DANGER("Your headgear melts away but protects you from the acid!"))
-					qdel(H.head)
-					H.update_inv_head(0)
-					H.update_hair(0)
-				else
-					to_chat(H, SPAN_WARNING("Your headgear protects you from the acid."))
-				return
-
-			if(H.wear_mask)
-				if(prob(meltprob) && !H.wear_mask.unacidable)
-					to_chat(H, SPAN_DANGER("Your mask melts away but protects you from the acid!"))
-					qdel(H.wear_mask)
-					H.update_inv_wear_mask(0)
-					H.update_hair(0)
-				else
-					to_chat(H, SPAN_WARNING("Your mask protects you from the acid."))
-				return
-
-			if(H.glasses) //Doesn't protect you from the acid but can melt anyways!
-				if(prob(meltprob) && !H.glasses.unacidable)
-					to_chat(H, SPAN_DANGER("Your glasses melts away!"))
-					qdel(H.glasses)
-					H.update_inv_glasses(0)
-
-		if(!M.unacidable)
-			if(istype(M, /mob/living/carbon/human) && volume >= 10)
-				var/mob/living/carbon/human/H = M
-				var/obj/limb/affecting = H.get_limb("head")
-				if(affecting)
-					if(affecting.take_damage(4, 2))
-						H.UpdateDamageIcon()
-					if(prob(meltprob)) //Applies disfigurement
-						if(H.pain.feels_pain)
-							H.emote("scream")
-						H.status_flags |= DISFIGURED
-						H.name = H.get_visible_name()
-			else
-				M.take_limb_damage(min(6, volume)) // uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
-	else
-		if(!M.unacidable)
-			M.take_limb_damage(min(6, volume))
-
-/datum/reagent/toxin/acid/reaction_obj(var/obj/O, var/volume)
-	if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(meltprob * 3))
-		if(!O.unacidable)
-			var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
-			I.desc = "Looks like this was \an [O] some time ago."
-			for(var/mob/M in viewers(5, O))
-				to_chat(M, SPAN_WARNING("\the [O] melts."))
-			qdel(O)
+	properties = list(PROPERTY_TOXIC = 1, PROPERTY_CORROSIVE = 3)
 
 /datum/reagent/toxin/acid/polyacid
 	name = "Polytrinic acid"

--- a/nano/templates/research_data.tmpl
+++ b/nano/templates/research_data.tmpl
@@ -9,18 +9,18 @@
 	{{/if}}
 	<br><br>
 	<h3>Purchase Report Access</h3>
-		{{:helper.link('Level 1 for 6 rc', 'arrowthickstop-1-s', {'purchase_document' : 1})}}
+		{{:helper.link('Level 1 for 7 rc', 'arrowthickstop-1-s', {'purchase_document' : 1})}}
 		{{if data.clearance_level >= 2 }}
 			{{:helper.link('Level 2 for 9 rc', 'arrowthickstop-1-s', {'purchase_document' : 2})}}
 		{{/if}}
 		{{if data.clearance_level >= 3 }}
-			{{:helper.link('Level 3 for 14 rc', 'arrowthickstop-1-s', {'purchase_document' : 3})}}
+			{{:helper.link('Level 3 for 11 rc', 'arrowthickstop-1-s', {'purchase_document' : 3})}}
 		{{/if}}
 		{{if data.clearance_level >= 4 }}
-			{{:helper.link('Level 4 for 21 rc', 'arrowthickstop-1-s', {'purchase_document' : 4})}}
+			{{:helper.link('Level 4 for 13 rc', 'arrowthickstop-1-s', {'purchase_document' : 4})}}
 		{{/if}}
 		{{if data.clearance_level >= 5 }}
-			{{:helper.link('Level 5 for 30 rc', 'arrowthickstop-1-s', {'purchase_document' : 5})}}
+			{{:helper.link('Level 5 for 15 rc', 'arrowthickstop-1-s', {'purchase_document' : 5})}}
 		{{/if}}
 	<br><br>
 	<h2>Research Data</h2>


### PR DESCRIPTION
* Adjusts stuff regarding reagents and adds some properties

* tweaks some stuff

* Adds reactions on mob/obj/turf touching for some chemical properties

this probably needs more testing

* Fixes extended point gain and changes a comment

* Adds components for slowing and reducing healing for xenos

Also adds components to the reaction_mob of some reagents

* fixes added components to actually work

also tweaks some stuff

* fixes some stuff that didn't get saved

* signs good

* tweaks heal reduction

* Makes xeno zoom drugs a reality

this is in no way a bad idea. At all. In any way.

* Adds techlevel-based limits to Create and Amplify modes

also tweaks a property

* tweaks property generation checks

* Adjusts potency thresholds for some effects

* tweaks some flame property related stuff

* Lowers property check threshold

* Replaces some magic numbers and changes some signals

* Fixes some code related to properties

* Fixes generated_properties list init and unique property generation

Hopefully this'll make the generated properties checker slightly less incredibly painful.

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* replaces most potency-related numbers with defines

Also moves the defines in research.dm to chemistry.dm

* More code fixes

Adds a couple early returns, makes generated_properties typed, and adds some defines to processes for some of the special properties

* Adds a cooldown to spray bottles and some misc. fixes

Spray bottle cooldown got suggested, probably a good idea given how spammable they would be otherwise.. Tweaked one of the properties, and also added a . = ..() call to extended/process() that probably should be there.

* Conflict fixes

* Adds a define to chem_simulator and removes a cast in prop_positive

* Adjusts stuff regarding reagents and adds some properties

* tweaks some stuff

* Adds reactions on mob/obj/turf touching for some chemical properties

this probably needs more testing

* Fixes extended point gain and changes a comment

* Adds components for slowing and reducing healing for xenos

Also adds components to the reaction_mob of some reagents

* fixes added components to actually work

also tweaks some stuff

* fixes some stuff that didn't get saved

* signs good

* tweaks heal reduction

* Makes xeno zoom drugs a reality

this is in no way a bad idea. At all. In any way.

* Adds techlevel-based limits to Create and Amplify modes

also tweaks a property

* tweaks property generation checks

* Adjusts potency thresholds for some effects

* tweaks some flame property related stuff

* Lowers property check threshold

* Replaces some magic numbers and changes some signals

* Fixes some code related to properties

* Fixes generated_properties list init and unique property generation

Hopefully this'll make the generated properties checker slightly less incredibly painful.

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* replaces most potency-related numbers with defines

Also moves the defines in research.dm to chemistry.dm

* More code fixes

Adds a couple early returns, makes generated_properties typed, and adds some defines to processes for some of the special properties

* Adds a cooldown to spray bottles and some misc. fixes

Spray bottle cooldown got suggested, probably a good idea given how spammable they would be otherwise.. Tweaked one of the properties, and also added a . = ..() call to extended/process() that probably should be there.

* Conflict fixes

* Adds a define to chem_simulator and removes a cast in prop_positive

* removes a thing I missed

* thing for a testmerge

needs to get reverted before full merge

* a couple cost-based tweaks

* Tweaks level restrictions to not use techwebs and instead use clearance

* Adjusts stuff regarding reagents and adds some properties

* tweaks some stuff

* Adds reactions on mob/obj/turf touching for some chemical properties

this probably needs more testing

* Fixes extended point gain and changes a comment

* Adds components for slowing and reducing healing for xenos

Also adds components to the reaction_mob of some reagents

* fixes added components to actually work

also tweaks some stuff

* fixes some stuff that didn't get saved

* signs good

* tweaks heal reduction

* Makes xeno zoom drugs a reality

this is in no way a bad idea. At all. In any way.

* Adds techlevel-based limits to Create and Amplify modes

also tweaks a property

* tweaks property generation checks

* Adjusts potency thresholds for some effects

* tweaks some flame property related stuff

* Lowers property check threshold

* Replaces some magic numbers and changes some signals

* Fixes some code related to properties

* Fixes generated_properties list init and unique property generation

Hopefully this'll make the generated properties checker slightly less incredibly painful.

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* replaces most potency-related numbers with defines

Also moves the defines in research.dm to chemistry.dm

* More code fixes

Adds a couple early returns, makes generated_properties typed, and adds some defines to processes for some of the special properties

* Adds a cooldown to spray bottles and some misc. fixes

Spray bottle cooldown got suggested, probably a good idea given how spammable they would be otherwise.. Tweaked one of the properties, and also added a . = ..() call to extended/process() that probably should be there.

* Conflict fixes

* Adds a define to chem_simulator and removes a cast in prop_positive

* Adjusts stuff regarding reagents and adds some properties

* tweaks some stuff

* Adds reactions on mob/obj/turf touching for some chemical properties

this probably needs more testing

* Fixes extended point gain and changes a comment

* Adds components for slowing and reducing healing for xenos

Also adds components to the reaction_mob of some reagents

* fixes added components to actually work

also tweaks some stuff

* fixes some stuff that didn't get saved

* signs good

* tweaks heal reduction

* Makes xeno zoom drugs a reality

this is in no way a bad idea. At all. In any way.

* Adds techlevel-based limits to Create and Amplify modes

also tweaks a property

* tweaks property generation checks

* Adjusts potency thresholds for some effects

* tweaks some flame property related stuff

* Lowers property check threshold

* Replaces some magic numbers and changes some signals

* Fixes some code related to properties

* Fixes generated_properties list init and unique property generation

Hopefully this'll make the generated properties checker slightly less incredibly painful.

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* Apply 1 suggestion(s) to 1 file(s)

* replaces most potency-related numbers with defines

Also moves the defines in research.dm to chemistry.dm

* More code fixes

Adds a couple early returns, makes generated_properties typed, and adds some defines to processes for some of the special properties

* Adds a cooldown to spray bottles and some misc. fixes

Spray bottle cooldown got suggested, probably a good idea given how spammable they would be otherwise.. Tweaked one of the properties, and also added a . = ..() call to extended/process() that probably should be there.

* Adds a define to chem_simulator and removes a cast in prop_positive

* removes a thing I missed

* thing for a testmerge

needs to get reverted before full merge

* a couple cost-based tweaks

* Tweaks level restrictions to not use techwebs and instead use clearance

* a couple tweaks and rebase fixes

* line fix

* fixes last conflicts (hopefully)

please tell me these are the last, I HATE FIXING VERY OLD MRs

* CLF3 Compensation

Chlorine Trifloudine used to ignite xenos before, lost it now so I gave it back the ability to ignite them again by increasing the potency of Oxidizing by 1. Hopefully it performs the same as it did before without being too OP.

* oxidizing agent begone!

Disabled the chemical Oxidizing Agent to appear in recipes due it's incredible rarity while it being borderline useless

* removed bloat

missed some code that got removed before

Co-authored-by: Ben <bbreslicH@gmail.com>
Co-authored-by: spookydonut <github@spooksoftware.com>
Co-authored-by: Ben <benbreslich@live.com>
Co-authored-by: Unknownity <a>